### PR TITLE
JSONインポート後にLocalStorageに保存するように変更

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -553,6 +553,10 @@ var Sys = React.createClass({
         var storedData = JSON.parse(this.state.rawData);
         this.setState({storedData: storedData});
         this.setState({selectedData: Object.keys(storedData)[0]});
+
+        // save data
+        var saveString = Base64.encodeURI(JSON.stringify(storedData));
+        localStorage.setItem("data", saveString);
     },
     render: function() {
         var locale = this.props.locale;


### PR DESCRIPTION
Issue #68 への対応。

※インポート直後にLocalStorageが上書きされるため、意図せずデータを破壊してしまうユーザが想定される。より親切にするにはconfirm的なダイアログを出すべきと思うが、Reactでのconfirmの実装が難しそうで手をつけていない