### PR TITLE
Fix - #101 武器の「削除」で前の武器の名称も消える 

### DIFF
--- a/src/armlist.js
+++ b/src/armlist.js
@@ -102,7 +102,7 @@ var ArmList = CreateClass({
         var newalist = this.state.alist;
         newalist[id] = initialState;
         this.setState({ alist: newalist })
-        if(newalist.length <= 1){
+        if(newalist.length < 1){
             // Root へ変化を伝搬
             this.props.onChange(newalist, false);
             return

--- a/src/armlist.js
+++ b/src/armlist.js
@@ -93,17 +93,22 @@ var ArmList = CreateClass({
         }
     },
     handleOnRemove: function (id, initialState) {
-        // arrayForCopyに初期stateを入れておいて、
-        // componentWillReceivePropsで読み出されるようにする
-        var newArrayForCopy = this.state.arrayForCopy;
-        newArrayForCopy[id] = initialState;
-        this.setState({ arrayForCopy: newArrayForCopy });
-
+    	var newarms = this.state.arms;
         var newalist = this.state.alist;
-        newalist[id] = initialState;
+        if(this.state.alist.length > 1){
+        	newarms.splice(id, 1);
+        	newalist.splice(id, 1);
+        }else{
+        	// arrayForCopyに初期stateを入れておいて、
+            // componentWillReceivePropsで読み出されるようにする
+        	var newArrayForCopy = this.state.arrayForCopy;
+            newArrayForCopy[id] = initialState;
+            this.setState({ arrayForCopy: newArrayForCopy });
+        	newalist[id] = initialState;
+        }
+        this.setState({ arms: newarms })
         this.setState({ alist: newalist })
 
-        newalist.splice(id, 1);
         // Root へ変化を伝搬
         this.props.onChange(newalist, false);
     },

--- a/src/armlist.js
+++ b/src/armlist.js
@@ -102,12 +102,8 @@ var ArmList = CreateClass({
         var newalist = this.state.alist;
         newalist[id] = initialState;
         this.setState({ alist: newalist })
-        if(newalist.length < 1){
-            // Root へ変化を伝搬
-            this.props.onChange(newalist, false);
-            return
-        }
-        newalist.splice(id - 1, 1);
+
+        newalist.splice(id, 1);
         // Root へ変化を伝搬
         this.props.onChange(newalist, false);
     },

--- a/src/armlist.js
+++ b/src/armlist.js
@@ -93,18 +93,18 @@ var ArmList = CreateClass({
         }
     },
     handleOnRemove: function (id, initialState) {
-    	var newarms = this.state.arms;
+        var newarms = this.state.arms;
         var newalist = this.state.alist;
         if(this.state.alist.length > 1){
-        	newarms.splice(id, 1);
-        	newalist.splice(id, 1);
+            newarms.splice(id, 1);
+            newalist.splice(id, 1);
         }else{
-        	// arrayForCopyに初期stateを入れておいて、
+            // arrayForCopyに初期stateを入れておいて、
             // componentWillReceivePropsで読み出されるようにする
-        	var newArrayForCopy = this.state.arrayForCopy;
+            var newArrayForCopy = this.state.arrayForCopy;
             newArrayForCopy[id] = initialState;
             this.setState({ arrayForCopy: newArrayForCopy });
-        	newalist[id] = initialState;
+            newalist[id] = initialState;
         }
         this.setState({ arms: newarms })
         this.setState({ alist: newalist })


### PR DESCRIPTION
#101 
spliceの引数を(id-1,1)から(id,1)に変更。これにより武器を削除したときにリストを詰める動作ができるようになります。
武器が1つしかない場合の削除ボタンは従来動作と同じくフォームのクリーンアップとしました。