### PR TITLE
バグ「武器タブへ遷移した直後に削除ボタンを押下するとクラッシュする（画面が真っ白になる）」問題を修正

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -225,6 +225,7 @@ var Root = CreateClass({
       var newArmNum = parseInt(this.state.armNum);
       if(newArmNum > 1) newArmNum -= 1
       this.setState({armNum: newArmNum});
+      this.setState({noResultUpdate: false});
   },
   addSummonNum: function(e) {
       var newSummonNum = parseInt(this.state.summonNum);


### PR DESCRIPTION
武器タブへ遷移した直後にはnoResultUpdateがTrueになっており、削除動作の際にresultがアップデートされずarm配列の範囲外にアクセスしにいくことが原因だと思われます。
また、「追加」ボタンにおいてはonChangeArmDataが発火することでresultがアップデートされるので問題が発生していないことも確認しました。（？「削除」ボタンでは発火しない）
以上から、noResultUpdateをfalseと明示することで解決しました。