### PR TITLE
docker-compose時にnode_moduleのパスが間違っていたので修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     command: npm run start
     volumes:
      - .:/app
-     - /node_modules
+     - /app/node_modules
     ports:
       - "8000:8000"
     networks:


### PR DESCRIPTION
https://github.com/MotocalDevelopers/motocal/issues/97
のissue対応です。

docker-compose起動時に`nodemodule`のパスが間違っていたので修正しました。
