### PR TITLE
Fix enemy defense translation

### DIFF
--- a/src/global_const.js
+++ b/src/global_const.js
@@ -979,7 +979,7 @@ module.exports.selector.zh.supported_simulationchartsortkeys = Object.keys(suppo
 module.exports.supportedChartSortkeys = supportedChartSortkeys
 module.exports.supportedSimulationChartSortkeys = supportedSimulationChartSortkeys
 
-module.exports.selector.ja.enemydeftypes = Object.keys(enemyDefenseType).map(function (opt) { return <option value={opt} key={opt}>{enemyDefenseType[opt].name}</option>; });
+module.exports.selector.ja.enemydeftypes = Object.keys(enemyDefenseType).map(function (opt) { return <option value={opt} key={opt}>{intl.translate(enemyDefenseType[opt].name, "ja")}</option>; });
 module.exports.selector.en.enemydeftypes = Object.keys(enemyDefenseType).map(function (opt) { return <option value={opt} key={opt}>{intl.translate(enemyDefenseType[opt].name, "en")}</option>; });
 module.exports.selector.zh.enemydeftypes = Object.keys(enemyDefenseType).map(function (opt) { return <option value={opt} key={opt}>{intl.translate(enemyDefenseType[opt].name, "zh")}</option>; });
 


### PR DESCRIPTION
"ja" locale was missing `enemydeftypes` translation.
An enemy defense type had enemy and debuf description, but they were not displayed in ja locale.

This PR implements a part of #147 
This PR does not effect to "en" and "zh" locales

敵防御値の説明はありましたが、日本語ロケールでは表示されていませんでした。