### PR TITLE
Add the total of Magna/Normal/Exceed ougi damage limits is 60%

### DIFF
--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -498,10 +498,13 @@ module.exports.calcBasedOneSummon = function(summonind, prof, buff, totals) {
 
         // 奥義ダメージ上限UP = 全体バフ + 個人バフ + スキル + ダメージ上限UP分
         // 奥義ダメージのスキル分上限は30%?
-        var ougiDamageLimitByExceed = (totals[key]["ougiDamageLimit"] > 0.30) ? 0.30 : totals[key]["ougiDamageLimit"]
-        var ougiDamageLimitByNormal = (totals[key]["normalOugiDamageLimit"] * totalSummon["zeus"] > 0.30) ? 0.30 : totals[key]["normalOugiDamageLimit"] * totalSummon["zeus"]
-        var ougiDamageLimitByMagna = (totals[key]["magnaOugiDamageLimit"] * totalSummon["magna"] > 0.30) ? 0.30 : totals[key]["magnaOugiDamageLimit"] * totalSummon["magna"]
-        var ougiDamageLimit = buff["ougiDamageLimit"] + totals[key]["ougiDamageLimitBuff"] + ougiDamageLimitByMagna + ougiDamageLimitByNormal + ougiDamageLimitByExceed
+        var ougiDamageLimitByExceed = Math.min(0.30, totals[key]["exceedOugiDamageLimit"]);
+        var ougiDamageLimitByNormal = Math.min(0.30, totals[key]["normalOugiDamageLimit"] * totalSummon["zeus"]);
+        var ougiDamageLimitByMagna = Math.min(0.30, totals[key]["magnaOugiDamageLimit"] * totalSummon["magna"]);
+        var ougiDamageLimit = Math.min(0.20, totals[key]["ougiDamageLimit"]);
+        ougiDamageLimit += Math.min(0.15, totals[key]["omegaOugiDamageLimit"]);
+        ougiDamageLimit += Math.min(0.60, (ougiDamageLimitByMagna + ougiDamageLimitByNormal + ougiDamageLimitByExceed));
+        ougiDamageLimit += buff["ougiDamageLimit"] + totals[key]["ougiDamageLimitBuff"];
 
         // damageは追加ダメージなしの単攻撃ダメージ(減衰・技巧補正あり)
         var damage = module.exports.calcDamage(summedAttack, totalSkillCoeff, criticalRatio, prof.enemyDefense, additionalDamage, damageUP, damageLimit)
@@ -1059,7 +1062,7 @@ module.exports.addSkilldataToTotals = function(totals, comb, arml, buff) {
                             if (gauphKeyType === "alpha") {
                                 totals[key]["normalDamageLimit"] += 0.1
                             } else if (gauphKeyType === "gamma") {
-                                totals[key]["ougiDamageLimit"] += 0.15
+                                totals[key]["omegaOugiDamageLimit"] += 0.15
                             }
                             isOmegaIncluded[gauphKeyType] = true;
                         }
@@ -1184,7 +1187,7 @@ module.exports.addSkilldataToTotals = function(totals, comb, arml, buff) {
                         } else if (stype == 'ougiDamageLimit') {
                             totals[key]["ougiDamageLimit"] += comb[i] * skillAmounts["ougiDamageLimit"][amount];
                         } else if (stype == 'ougiDamageLimitExceed') {
-                            totals[key]["ougiDamageLimit"] += 0.01 * comb[i] * skillAmounts["ougiDamageLimitExceed"][amount][slv - 1];
+                            totals[key]["exceedOugiDamageLimit"] += 0.01 * comb[i] * skillAmounts["ougiDamageLimitExceed"][amount][slv - 1];
                         //! 4凸武器スキル
                         } else if(stype == 'tsuranukiKiba'){
                             if(skillname == 'tsuranukiKibaMain'){
@@ -1402,6 +1405,8 @@ module.exports.getInitialTotals = function(prof, chara, summon) {
             ougiDamageLimit: 0,
             magnaOugiDamageLimit: 0,
             normalOugiDamageLimit: 0,
+            exceedOugiDamageLimit: 0,
+            omegaOugiDamageLimit: 0,
             additionalDamage: 0,
             ougiDebuff: 0,
             isConsideredInAverage: true,
@@ -1664,6 +1669,8 @@ module.exports.initializeTotals = function(totals) {
         totals[key]["ougiDamageLimit"] = 0;
         totals[key]["magnaOugiDamageLimit"] = 0;
         totals[key]["normalOugiDamageLimit"] = 0;
+        totals[key]["exceedOugiDamageLimit"] = 0;
+        totals[key]["omegaOugiDamageLimit"] = 0;
         totals[key]["additionalDamage"] = 0;
         totals[key]["ougiDebuff"] = 0;
         totals[key]["DAbuff"] = 0;


### PR DESCRIPTION
This patch implements a part of Issue #155 
That reported the sum of Magna,Normal,Exceed Ougi damage Limits has 60% limit.

The change contains bug fix:
Omega and others were calculated as Exceed, they are out of this limit.

方陣+通常+イクシードの合算枠上限を60%に設定。
オメガキーや他枠がイクシード枠の上限に引っかかっていたのを解消。