### PR TITLE
Fix magnaCritical skill calculation

### DIFF
--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -1503,6 +1503,8 @@ module.exports.addSkilldataToTotals = function (totals, comb, arml, buff) {
                                 if (totals[key]["race"] === "seisho" || totals[key]["support"] === "wildcard") {
                                     totals[key]["magna"] += comb[i] * skillAmounts["magna"][amount][slv - 1];
                                 }
+                            } else if (stype == 'magnaCritical') {
+                                totals[key][stype] += comb[i] * skillAmounts['critical'][amount][slv - 1];
                             } else {
                                 totals[key][stype] += comb[i] * skillAmounts[stype][amount][slv - 1];
                             }


### PR DESCRIPTION
reported on #162

skillAmounts table missing 'magnaCritical' key
This change was in 2019-04-26 patch.

normalCritical and magnaCritical keys unified to 'critical'
now we need to catch magnaCritical stype.

2019-04-26のパッチ適応以降、
マグナ技巧の計算でエラーが出ていました。
（内部処理の変更のため、編成データ等への影響はありません）

This patch will resolve #162