### PR TITLE
Partial Load feature

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -145,9 +145,12 @@
 
     .dataControl .systemButtonGroup {
         width: 100%;
+        text-align: center;
     }
     .dataControl .systemButton {
+        /*
         width: calc(100%/3);
+        */
     }
 
     .tweet .tweetButton {

--- a/src/content.js
+++ b/src/content.js
@@ -669,10 +669,14 @@ var Sys = CreateClass({
                     <Button bsStyle="primary" className="systemButton"
                             onClick={this.onSubmitLoad}>{intl.translate("ブラウザデータ読込", locale)}</Button>
                     <DropdownButton title="&nbsp;" bsStyle="primary" className="systemButton" id="partial-load-menu">
-                        <MenuItem onClick={this.onSubmitPartialLoad.bind(this, 'profile')}>Load Djeeta</MenuItem>
-                        <MenuItem onClick={this.onSubmitPartialLoad.bind(this, 'summon')}>Load Summon</MenuItem>
-                        <MenuItem onClick={this.onSubmitPartialLoad.bind(this, 'chara')}>Load Charactor</MenuItem>
-                        <MenuItem onClick={this.onSubmitPartialLoad.bind(this, 'armlist')}>Load Weapon</MenuItem>
+                        <MenuItem onClick={this.onSubmitPartialLoad.bind(this, 'profile')}>
+                            {intl.translate("ジータ読込", locale)}</MenuItem>
+                        <MenuItem onClick={this.onSubmitPartialLoad.bind(this, 'summon')}>
+                            {intl.translate("召喚石読込", locale)}</MenuItem>
+                        <MenuItem onClick={this.onSubmitPartialLoad.bind(this, 'chara')}>
+                            {intl.translate("キャラ読込", locale)}</MenuItem>
+                        <MenuItem onClick={this.onSubmitPartialLoad.bind(this, 'armlist')}>
+                            {intl.translate("武器読込", locale)}</MenuItem>
                     </DropdownButton>
                     <Button bsStyle="primary" className="systemButton"
                             onClick={this.onSubmitRemove}>{intl.translate("削除", locale)}</Button>

--- a/src/content.js
+++ b/src/content.js
@@ -543,6 +543,44 @@ var Sys = CreateClass({
             alert("削除するデータを選択して下さい。")
         }
     },
+    onSubmitPartialLoad: function(key, e) {
+        e.preventDefault();
+        if (this.state.selectedData != '') {
+            var newData = JSON.parse(JSON.stringify(this.state.storedData[this.state.selectedData]));
+            var oldData = this.props.data;
+            var dataForLoad = {
+                profile: oldData.profile,
+                summon: oldData.summon,
+                chara: oldData.chara,
+                armlist: oldData.armlist,
+                simulator: oldData.simulator,
+                summonNum: oldData.summonNum,
+                charaNum: oldData.charaNum,
+                armNum: oldData.armNum,
+            };
+
+            dataForLoad[key] = newData[key];
+
+            switch (key) {
+            case 'profile':
+                break;
+            case 'summon':
+                dataForLoad.summonNum = newData.summonNum;
+                break;
+            case 'chara':
+                dataForLoad.charaNum = newData.charaNum;
+                break;
+            case 'armlist':
+                dataForLoad.armNum = newData.armNum;
+                break;
+            }
+
+            this.setState({dataName: this.state.selectedData});
+            this.props.onLoadNewData(this.state.selectedData, dataForLoad)
+        } else {
+            alert("読み込むデータを選択して下さい。")
+        }
+    },
     onSubmitLoad: function (e) {
         e.preventDefault();
         if (this.state.selectedData != '') {
@@ -630,6 +668,12 @@ var Sys = CreateClass({
                             onClick={this.onSubmitSave}>{intl.translate("ブラウザに保存", locale)}</Button>
                     <Button bsStyle="primary" className="systemButton"
                             onClick={this.onSubmitLoad}>{intl.translate("ブラウザデータ読込", locale)}</Button>
+                    <DropdownButton title="&nbsp;" bsStyle="primary" className="systemButton" id="partial-load-menu">
+                        <MenuItem onClick={this.onSubmitPartialLoad.bind(this, 'profile')}>Load Djeeta</MenuItem>
+                        <MenuItem onClick={this.onSubmitPartialLoad.bind(this, 'summon')}>Load Summon</MenuItem>
+                        <MenuItem onClick={this.onSubmitPartialLoad.bind(this, 'chara')}>Load Charactor</MenuItem>
+                        <MenuItem onClick={this.onSubmitPartialLoad.bind(this, 'armlist')}>Load Weapon</MenuItem>
+                    </DropdownButton>
                     <Button bsStyle="primary" className="systemButton"
                             onClick={this.onSubmitRemove}>{intl.translate("削除", locale)}</Button>
                 </ButtonGroup>

--- a/src/translate.js
+++ b/src/translate.js
@@ -76,6 +76,26 @@ var multiLangData = {
         "ja": "保存",
         "zh": "保存",
     },
+    "ジータ読込": {
+        "en": "Load Djeeta",
+        "ja": "ジータの読込",
+        "zh": "Load Djeeta",
+    },
+    "召喚石読込": {
+        "en": "Load Summon",
+        "ja": "召喚石の読込",
+        "zh": "Load Summon",
+    },
+    "キャラ読込": {
+        "en": "Load Character",
+        "ja": "キャラの読込",
+        "zh": "Load Character",
+    },
+    "武器読込": {
+        "en": "Load Weapon",
+        "ja": "武器の読込",
+        "zh": "Load Weapon",
+    },
     "データ移行": {
         "en": "Export/Import",
         "ja": "データ移行",


### PR DESCRIPTION
This patch add dropdown button for partial loading

![partial-load](https://user-images.githubusercontent.com/45387555/57249200-4a3a4100-707f-11e9-97fc-91734347bdee.png)

This change makes users manages their save data as Preset.
e.g. Load earth-katana party + Load earth-magna2 weapons.

Save data will become more re-usable.

----

## TODO

- [x] translate button labels
- [ ] CSS (English locale break button group layout)
- [ ] need review about `simulator`

----

__This is an experimental feature, yet__

The partial loading may break user's save data,
If user had clicked the load button by mistake, but there is no Revert.

Please save a backup, then try at your own risk.