### PR TITLE
Fix Akasha-bow Critical Skill effect size

### DIFF
--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -1296,8 +1296,8 @@ module.exports.addSkilldataToTotals = function (totals, comb, arml, buff) {
                                 if (!isAkashaIncludedGlobal || isAkashaIncludedLocal[akashaType]) {
                                     totals[key]["akashaATK"] += 20.0;
                                     totals[key]["normalOtherCritical"].push({
-                                        "value": 0.01 * 10.0,
-                                        "attackRatio": 0.45
+                                        "value": 0.01 * 20.0,
+                                        "attackRatio": 0.50
                                     });
                                     isAkashaIncludedGlobal = true;
                                     isAkashaIncludedLocal[akashaType] = true;


### PR DESCRIPTION
> 虚像の鋒鏑：得意武器「弓」「銃」キャラの攻撃UP（EX枠20%）/クリ率UP（倍率50%/発生率約20%）

http://gbf-verification.blog.jp/archives/14717421.html