### PR TITLE
Fix Belltower Skill

### DIFF
--- a/armData.json
+++ b/armData.json
@@ -11469,7 +11469,7 @@
         "ja": "ベルタワー",
         "element": "wind",
         "type": "axe",
-        "skill1": "non",
+        "skill1": "strengthL",
         "skill2": "non",
         "element2": "wind",
         "skill3": "non",

--- a/scripts/arm_data_converter.py
+++ b/scripts/arm_data_converter.py
@@ -768,6 +768,7 @@ skillnamelist["strengthL"] = {
     u"ゲイルオブアームズ": "wind",
     u"獅子と牛の咆哮": "dark",
     u"サイコ攻刃": "earth",
+    u"心頭滅欲": "earth",
 }
 
 skillnamelist["exATKandHPM"] = {


### PR DESCRIPTION
要望フォームより

> ベルタワー（風・斧）＜2018年1月イベント報酬SSR武器＞
> 　スキル部分が全部「無し」となっている
> 　正しくは第2スキル「菩提の探究（EX攻刃枠・大）※Lv.100解放」であります