### PR TITLE
Fix issue #188 skill data was not add to result

### DIFF
--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -904,7 +904,7 @@ function* eachSkill(arm) {
         ["skill2", "element2"],
         ["skill3", "element3"],
     ];
-    for (let {skey,ekey} of _skill_element_keys) {
+    for (let [skey, ekey] of _skill_element_keys) {
         var skillname = arm[skey] ? arm[skey] : "non";
         var element = arm[ekey] != undefined ? arm[ekey] : "fire";
         if (typeof skilltypes[skillname] === 'undefined') {
@@ -1096,7 +1096,7 @@ module.exports.addSkilldataToTotals = function (totals, comb, arml, buff) {
                 }
                 totals[key]["armAttack"] += armSup * parseInt(arm.attack) * comb[i];
                 totals[key]["armHP"] += hpSup * parseInt(arm.hp) * comb[i];
-                for (let {skillname, element} of eachSkill(arm)) {
+                for (let [skillname, element] of eachSkill(arm)) {
                     var stype = skilltypes[skillname].type;
                     var amount = skilltypes[skillname].amount;
                     var slv = parseInt(arm.slv);
@@ -2324,7 +2324,7 @@ module.exports.generateHaisuiData = function (res, arml, summon, prof, chara, st
 
                     if (storedCombinations[j][i] === 0) continue;
 
-                    for (let {skillname, element} of eachSkill(arm[i])) {
+                    for (let [skillname, element] of eachSkill(arm)) {
                         var stype = skilltypes[skillname].type;
                         var amount = skilltypes[skillname].amount;
                         var slv = parseInt(arm.slv);


### PR DESCRIPTION
fix #188 

- [x] スキルデータが計算結果に反映されない不具合
  eachSkill 内の処理修正。
- [x] 背水関連のスキルデータが反映されていなかった問題修正
  generateHaisuiData 関数内で eachSkill に渡している引数を修正。
 （今回報告のあったのとは別問題） 

サポートアビリティに関しては同様の問題は見当たりませんでした。