### PR TITLE
Install devDependencies on Heroku deploy

### DIFF
--- a/Dockerfile.heroku
+++ b/Dockerfile.heroku
@@ -2,7 +2,7 @@ FROM node:8-alpine as builder
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm install --only=production --no-progress
+RUN npm install --no-progress
 
 COPY . .
 RUN npm run production-build
@@ -13,4 +13,3 @@ FROM nginx:1.12-alpine
 COPY --from=builder /app/dist/ /usr/share/nginx/html
 COPY default.conf.tmpl /etc/nginx/conf.d/
 CMD envsubst < /etc/nginx/conf.d/default.conf.tmpl > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'
-


### PR DESCRIPTION
fix https://github.com/MotocalDevelopers/motocal/issues/202

詳しい原因は調べきれなかったんだけど https://github.com/MotocalDevelopers/motocal/pull/180 のタイミングで devDependencies も存在しないとビルドできなくなっているようでした。

`docker build -f Dockerfile.heroku .` を実行してビルド確認しました。