### PR TITLE
Fix Storybook configuration

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "@babel/preset-react"
+  ],
+  "plugins": [
+    "transform-inline-environment-variables"
+  ]
+}


### PR DESCRIPTION
Storybook did not work.
npm run storybook show warning to load Motocal's components.
Seem default config is changed by Babel updates.

This patch is a temporary solution
enable babel config by Copy .babelrc to .storybook/
(This make duplicate .babelrc, so it's temporary)

TODO: Add custom webpack config to load the root .babelrc