### PR TITLE
 Fix sort of ougi with chain damage / ougi damage

### DIFF
--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -817,7 +817,7 @@ module.exports.calcBasedOneSummon = function (summonind, prof, buff, totals) {
     res["Djeeta"]["averageCyclePerTurn"] = averageCyclePerTurn / cnt;
     res["Djeeta"]["averageChainBurst"] = averageChainBurst / cnt;
     res["Djeeta"]["totalOugiDamage"] = totalOugiDamage;
-    res["Djeeta"]["totalOugiDamageWithChain"] = res["Djeeta"]["averageChainBurst"];
+    res["Djeeta"]["totalOugiDamageWithChain"] = totalOugiDamage + res["Djeeta"]["averageChainBurst"];
 
     for (var key in totals) {
         res[key]["totalOugiDamage"] = totalOugiDamage;

--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -781,7 +781,6 @@ module.exports.calcBasedOneSummon = function (summonind, prof, buff, totals) {
             damageWithCritical: damage,
             // Only consecutive shots
             damageWithMultiple: damageWithoutCritical * expectedAttack,
-            ougiDamageWithChainDamage: ougiDamage + chainBurst,
             ougiRatio: totals[key]["ougiRatio"],
             ougiDamage: ougiDamage,
             chainBurst: chainBurst,
@@ -797,7 +796,7 @@ module.exports.calcBasedOneSummon = function (summonind, prof, buff, totals) {
     var totalExpected_average = 0.0;
     var averageCyclePerTurn = 0.0;
     var averageChainBurst = 0.0;
-    var totalOugiDamageWithChain = 0.0;
+    var totalOugiDamage = 0.0;
 
     var cnt = 0.0;
     for (key in res) {
@@ -807,7 +806,7 @@ module.exports.calcBasedOneSummon = function (summonind, prof, buff, totals) {
             totalExpected_average += res[key].totalExpected;
             averageCyclePerTurn += res[key].expectedCycleDamagePerTurn;
             averageChainBurst += res[key].chainBurst;
-            totalOugiDamageWithChain += res[key].ougiDamage;
+            totalOugiDamage += res[key].ougiDamage;
             cnt += 1.0
         }
     }
@@ -817,8 +816,15 @@ module.exports.calcBasedOneSummon = function (summonind, prof, buff, totals) {
     res["Djeeta"]["averageTotalExpected"] = parseInt(totalExpected_average / cnt);
     res["Djeeta"]["averageCyclePerTurn"] = parseInt(averageCyclePerTurn / cnt);
     res["Djeeta"]["averageChainBurst"] = parseInt(averageChainBurst / cnt);
-    res["Djeeta"]["totalOugiDamageWithChain"] = totalOugiDamageWithChain + res["Djeeta"]["averageChainBurst"];
-    return res
+    res["Djeeta"]["totalOugiDamage"] = totalOugiDamage;
+    res["Djeeta"]["totalOugiDamageWithChain"] = totalOugiDamage + chainBurst;
+
+    for (var key in totals) {
+        res[key]["totalOugiDamage"] = totalOugiDamage;
+        res[key]["ougiDamageWithChainDamage"] = totalOugiDamage + chainBurst;
+    }
+
+    return res;
 };
 
 module.exports.getTesukatoripokaAmount = function (amount, numOfRaces) {

--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -811,11 +811,11 @@ module.exports.calcBasedOneSummon = function (summonind, prof, buff, totals) {
         }
     }
 
-    res["Djeeta"]["averageAttack"] = parseInt(average / cnt);
-    res["Djeeta"]["averageCriticalAttack"] = parseInt(crit_average / cnt);
-    res["Djeeta"]["averageTotalExpected"] = parseInt(totalExpected_average / cnt);
-    res["Djeeta"]["averageCyclePerTurn"] = parseInt(averageCyclePerTurn / cnt);
-    res["Djeeta"]["averageChainBurst"] = parseInt(averageChainBurst / cnt);
+    res["Djeeta"]["averageAttack"] = average / cnt;
+    res["Djeeta"]["averageCriticalAttack"] = crit_average / cnt;
+    res["Djeeta"]["averageTotalExpected"] = totalExpected_average / cnt;
+    res["Djeeta"]["averageCyclePerTurn"] = averageCyclePerTurn / cnt;
+    res["Djeeta"]["averageChainBurst"] = averageChainBurst / cnt;
     res["Djeeta"]["totalOugiDamage"] = totalOugiDamage;
     res["Djeeta"]["totalOugiDamageWithChain"] = totalOugiDamage + chainBurst;
 

--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -797,6 +797,7 @@ module.exports.calcBasedOneSummon = function (summonind, prof, buff, totals) {
     var totalExpected_average = 0.0;
     var averageCyclePerTurn = 0.0;
     var averageChainBurst = 0.0;
+    var totalOugiDamageWithChain = 0.0;
 
     var cnt = 0.0;
     for (key in res) {
@@ -806,6 +807,7 @@ module.exports.calcBasedOneSummon = function (summonind, prof, buff, totals) {
             totalExpected_average += res[key].totalExpected;
             averageCyclePerTurn += res[key].expectedCycleDamagePerTurn;
             averageChainBurst += res[key].chainBurst;
+            totalOugiDamageWithChain += res[key].ougiDamage;
             cnt += 1.0
         }
     }
@@ -815,6 +817,7 @@ module.exports.calcBasedOneSummon = function (summonind, prof, buff, totals) {
     res["Djeeta"]["averageTotalExpected"] = parseInt(totalExpected_average / cnt);
     res["Djeeta"]["averageCyclePerTurn"] = parseInt(averageCyclePerTurn / cnt);
     res["Djeeta"]["averageChainBurst"] = parseInt(averageChainBurst / cnt);
+    res["Djeeta"]["totalOugiDamageWithChain"] = totalOugiDamageWithChain + res["Djeeta"]["averageChainBurst"];
     return res
 };
 

--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -817,11 +817,11 @@ module.exports.calcBasedOneSummon = function (summonind, prof, buff, totals) {
     res["Djeeta"]["averageCyclePerTurn"] = averageCyclePerTurn / cnt;
     res["Djeeta"]["averageChainBurst"] = averageChainBurst / cnt;
     res["Djeeta"]["totalOugiDamage"] = totalOugiDamage;
-    res["Djeeta"]["totalOugiDamageWithChain"] = totalOugiDamage + chainBurst;
+    res["Djeeta"]["totalOugiDamageWithChain"] = res["Djeeta"]["averageChainBurst"];
 
     for (var key in totals) {
         res[key]["totalOugiDamage"] = totalOugiDamage;
-        res[key]["ougiDamageWithChainDamage"] = totalOugiDamage + chainBurst;
+        res[key]["ougiDamageWithChainDamage"] = totalOugiDamage + res["Djeeta"]["averageChainBurst"];
     }
 
     return res;

--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -258,7 +258,7 @@ module.exports.calcChainBurst = function (ougiDamage, chainNumber, typeBonus, ch
     if (chainNumber <= 2) {
         var limitValues = [[1500000, 0.01], [1300000, 0.05], [1200000, 0.30], [1000000, 0.60]]
     } else if (chainNumber === 3) {
-        var limitValues = [[2000000, 0.01], [1600000, 0.05], [1400000, 0.30], [1200000, 0.60]]
+        var limitValues = [[2000000, 0.01], [1500000, 0.05], [1450000, 0.30], [1250000, 0.60]]
     } else {
         var limitValues = [[2500000, 0.01], [1800000, 0.05], [1700000, 0.30], [1500000, 0.60]]
     }

--- a/src/result.js
+++ b/src/result.js
@@ -205,6 +205,7 @@ var ResultList = CreateClass({
             switchAverageCycleDamage: 1,
             switchDebuffResistance: 0,
             switchChainBurst: 0,
+            switchTotalOugiDamageWithChain: 0,
             disableAutoResultUpdate: 0,
             result: {summon: this.props.summon, result: []},
             chartSortKey: "totalAttack",
@@ -437,6 +438,9 @@ var ResultList = CreateClass({
         if (switcher.switchChainBurst) {
             tableheader.push(intl.translate("チェインバースト", locale))
         }
+        if (switcher.switchTotalOugiDamageWithChain) {
+            tableheader.push(intl.translate("奥義+チェンバダメージ", locale))
+        }
         if (switcher.switchCycleDamage) {
             tableheader.push(intl.translate("予想ターン毎ダメージ", locale))
         }
@@ -554,6 +558,9 @@ var ResultList = CreateClass({
                                 </td>
                                 <td onClick={this.handleEvent.bind(this, "switchChainBurst")}
                                     className={(this.state.switchChainBurst == 1) ? "display-checked" : "display-unchecked"}> チェインバースト
+                                </td>
+                                <td onClick={this.handleEvent.bind(this, "switchTotalOugiDamageWithChain")}
+                                    className={(this.state.switchTotalOugiDamageWithChain == 1) ? "display-checked" : "display-unchecked"}> 奥義+チェンバダメージ
                                 </td>
                                 <td onClick={this.handleEvent.bind(this, "switchCharaAttack")}
                                     className={(this.state.switchCharaAttack == 1) ? "display-checked" : "display-unchecked"}> キャラ攻撃力
@@ -757,6 +764,8 @@ var ResultList = CreateClass({
                                       active={(this.state.switchOugiDamage == 1) ? true : false}> {intl.translate("奥義ダメージ", locale)} </MenuItem>
                             <MenuItem onClick={this.handleEvent.bind(this, "switchChainBurst")}
                                       active={(this.state.switchChainBurst == 1) ? true : false}> {intl.translate("チェインバースト", locale)} </MenuItem>
+                            <MenuItem onClick={this.handleEvent.bind(this, "switchTotalOugiDamageWithChain")}
+                                      active={(this.state.switchTotalOugiDamageWithChain == 1) ? true : false}> {intl.translate("奥義+チェンバダメージ", locale)} </MenuItem>
                             <MenuItem onClick={this.handleEvent.bind(this, "switchOugiGage")}
                                       active={(this.state.switchOugiGage == 1) ? true : false}> {intl.translate("ターン毎の奥義ゲージ上昇量", locale)} </MenuItem>
                         </DropdownButton>
@@ -1166,6 +1175,10 @@ var Result = CreateClass({
 
                 if (sw.switchChainBurst) {
                     tablebody.push(parseInt(m.data.Djeeta.averageChainBurst));
+                    ++colSize;
+                }
+                if (sw.switchTotalOugiDamageWithChain) {
+                    tablebody.push(Math.round(m.data.Djeeta.totalOugiDamageWithChain));
                     ++colSize;
                 }
                 if (sw.switchCycleDamage) {

--- a/src/result.js
+++ b/src/result.js
@@ -985,8 +985,8 @@ var Result = CreateClass({
                     ++colSize;
                 }
                 if (sw.switchATKandHP) {
-                    var senryoku = parseInt(m.data.Djeeta.displayAttack) + parseInt(m.data.Djeeta.displayHP);
-                    tablebody.push(senryoku + "\n(" + parseInt(m.data.Djeeta.displayAttack) + ' + ' + parseInt(m.data.Djeeta.displayHP) + ')');
+                    var senryoku = Math.round(m.data.Djeeta.displayAttack) + Math.round(m.data.Djeeta.displayHP);
+                    tablebody.push(senryoku + "\n(" + Math.round(m.data.Djeeta.displayAttack) + ' + ' + Math.round(m.data.Djeeta.displayHP) + ')');
                     ++colSize;
                 }
 
@@ -1042,7 +1042,7 @@ var Result = CreateClass({
                 }
 
                 if (sw.switchExpectedAttack) {
-                    var expectedAttack = parseInt(m.data.Djeeta.expectedAttack * m.data.Djeeta.totalAttack);
+                    var expectedAttack = Math.round(m.data.Djeeta.expectedAttack * m.data.Djeeta.totalAttack);
                     tablebody.push(m.data.Djeeta.expectedAttack.toFixed(4) + "\n(" + expectedAttack + ")");
                     ++colSize;
                 }
@@ -1063,7 +1063,7 @@ var Result = CreateClass({
                 }
 
                 if (sw.switchHP) {
-                    tablebody.push(m.data.Djeeta.totalHP + "\n(" + parseInt(m.data.Djeeta.totalHP * m.data.Djeeta.remainHP) + ")");
+                    tablebody.push(m.data.Djeeta.totalHP + "\n(" + Math.round(m.data.Djeeta.totalHP * m.data.Djeeta.remainHP) + ")");
                     ++colSize;
                 }
 
@@ -1073,19 +1073,19 @@ var Result = CreateClass({
                             <span key={key + "-HP"} className="result-chara-detail">
                                     <span
                                         className="label label-success">{intl.translate("残HP", locale)} / HP</span>&nbsp;
-                                {parseInt(m.data[key].totalHP * m.data[key].remainHP)}&nbsp;/&nbsp;{m.data[key].totalHP}&nbsp;
+                                {Math.round(m.data[key].totalHP * m.data[key].remainHP)}&nbsp;/&nbsp;{m.data[key].totalHP}&nbsp;
                                 </span>
                         );
                     }
                 }
 
                 if (sw.switchAverageAttack) {
-                    tablebody.push(parseInt(m.data.Djeeta.averageAttack));
+                    tablebody.push(Math.round(m.data.Djeeta.averageAttack));
                     ++colSize;
                 }
 
                 if (sw.switchAverageCriticalAttack) {
-                    tablebody.push(m.data.Djeeta.averageCriticalAttack);
+                    tablebody.push(Math.round(m.data.Djeeta.averageCriticalAttack));
                     ++colSize;
                 }
 
@@ -1106,12 +1106,12 @@ var Result = CreateClass({
                 }
 
                 if (sw.switchAverageTotalExpected) {
-                    tablebody.push(m.data.Djeeta.averageTotalExpected);
+                    tablebody.push(Math.round(m.data.Djeeta.averageTotalExpected));
                     ++colSize;
                 }
 
                 if (sw.switchPureDamage) {
-                    tablebody.push(parseInt(m.data.Djeeta.pureDamage));
+                    tablebody.push(Math.round(m.data.Djeeta.pureDamage));
                     ++colSize;
                 }
 
@@ -1127,17 +1127,17 @@ var Result = CreateClass({
                 }
 
                 if (sw.switchDamageWithCritical) {
-                    tablebody.push(parseInt(m.data.Djeeta.damageWithCritical));
+                    tablebody.push(Math.round(m.data.Djeeta.damageWithCritical));
                     ++colSize;
                 }
 
                 if (sw.switchDamageWithMultiple) {
-                    tablebody.push(parseInt(m.data.Djeeta.damageWithMultiple));
+                    tablebody.push(Math.round(m.data.Djeeta.damageWithMultiple));
                     ++colSize;
                 }
 
                 if (sw.switchDamage) {
-                    tablebody.push(parseInt(m.data.Djeeta.damage));
+                    tablebody.push(Math.round(m.data.Djeeta.damage));
                     ++colSize;
                 }
 
@@ -1147,7 +1147,7 @@ var Result = CreateClass({
                 }
 
                 if (sw.switchOugiDamage) {
-                    tablebody.push(parseInt(m.data.Djeeta.totalOugiDamage));
+                    tablebody.push(Math.round(m.data.Djeeta.totalOugiDamage));
                     ++colSize;
                 }
 
@@ -1174,7 +1174,7 @@ var Result = CreateClass({
                 }
 
                 if (sw.switchChainBurst) {
-                    tablebody.push(parseInt(m.data.Djeeta.averageChainBurst));
+                    tablebody.push(Math.round(m.data.Djeeta.averageChainBurst));
                     ++colSize;
                 }
                 if (sw.switchTotalOugiDamageWithChain) {
@@ -1182,7 +1182,7 @@ var Result = CreateClass({
                     ++colSize;
                 }
                 if (sw.switchCycleDamage) {
-                    tablebody.push(parseInt(m.data.Djeeta.expectedCycleDamagePerTurn));
+                    tablebody.push(Math.round(m.data.Djeeta.expectedCycleDamagePerTurn));
                     ++colSize;
                 }
 
@@ -1198,7 +1198,7 @@ var Result = CreateClass({
                 }
 
                 if (sw.switchAverageCycleDamage) {
-                    var val = parseInt(m.data.Djeeta.averageCyclePerTurn);
+                    var val = Math.round(m.data.Djeeta.averageCyclePerTurn);
                     tablebody.push(val.toString() + " (" + (4 * val).toString() + ")");
                     ++colSize;
                 }

--- a/src/result.js
+++ b/src/result.js
@@ -1147,7 +1147,7 @@ var Result = CreateClass({
                 }
 
                 if (sw.switchOugiDamage) {
-                    tablebody.push(parseInt(m.data.Djeeta.ougiDamage));
+                    tablebody.push(parseInt(m.data.Djeeta.totalOugiDamage));
                     ++colSize;
                 }
 


### PR DESCRIPTION
- Display total of ougi damege with chain

- Fix sort of ougi with chain damage / ougi damage
→ Because so far ougi with chain damage / ougi damage was only djeeta's having, change to whole party.

- replace parseInt for Math.round when display
No problem for now

![image](https://user-images.githubusercontent.com/22173829/59259697-3b920b80-8c75-11e9-83d7-90db38fec064.png)

----
I hope someone implement twice C.A. (200% gage chara, Kengo, Chrysaor)
It will get better to able to change first and second C.A. raito If do Chrysaor.