### PR TITLE
Add Per Character Enemy Defense

### DIFF
--- a/src/chara.js
+++ b/src/chara.js
@@ -3,6 +3,7 @@ var intl = require('./translate.js');
 var {Label, Checkbox, FormControl, InputGroup, FormGroup, Button, ButtonGroup, Panel, PanelGroup, Modal, Glyphicon} = require('react-bootstrap');
 var CreateClass = require('create-react-class');
 var {RegisteredChara} = require('./template.js');
+var EnemyDefense = require('./enemy_defense.js');
 var GlobalConst = require('./global_const.js');
 
 // inject GlobalConst...
@@ -309,6 +310,9 @@ var Chara = CreateClass({
             EXLBKonshin: 0,
             EXLBDA: 0,
             EXLBTA: 0,
+            manualEnemyDefense: false,
+            enemyDefense: 10.0,
+            defenseDebuff: 0.0,
         };
     },
     componentDidMount: function () {
@@ -570,6 +574,43 @@ var Chara = CreateClass({
                                          onChange={this.handleSelectEvent.bind(this, "support3")}>{selector[locale].supportAbilities}</FormControl>
                         </td>
                     </tr>
+
+                    {EnemyDefense.perCharaEnemyDefense
+                     ? [
+                        <tr>
+                            <th className="bg-primary">
+                                {intl.translate("敵防御固有値", locale)}
+                                <Checkbox inline checked={this.state.manualEnemyDefense}
+                                          onChange={this.handleSelectEvent.bind(this, "manualEnemyDefense")}>
+                                 <strong>{intl.translate("素敵な防御値", locale)}</strong>
+                                </Checkbox>
+                            </th>
+                            <td>
+                                {this.state.manualEnemyDefense
+                                 ?
+                                    <FormControl type="number" min="0" step="0.5" value={this.state.enemyDefense}
+                                                 onBlur={this.handleOnBlur}
+                                                 onChange={this.handleEvent.bind(this, "enemyDefense")}/>
+                                 :
+                                    <FormControl componentClass="select" value={this.state.enemyDefense}
+                                                 onChange={this.handleSelectEvent.bind(this, "enemyDefense")}> {selector[locale].enemydeftypes} </FormControl>
+                                }
+                             </td>
+                        </tr>,
+                        <tr>
+                            <th className="bg-primary">{intl.translate("防御デバフ合計", locale)}</th>
+                                <td>
+                                    <InputGroup>
+                                        <FormControl type="number" min="0" step="5" max="100" value={this.state.defenseDebuff}
+                                            onBlur={this.handleOnBlur}
+                                            onChange={this.handleEvent.bind(this, "defenseDebuff")}/>
+                                        <InputGroup.Addon>%</InputGroup.Addon>
+                                    </InputGroup>
+                                </td>
+                        </tr>
+                     ] : 
+                        null
+                    }
 
                     <tr>
                         <th className="bg-primary"><Button

--- a/src/enemy_defense.js
+++ b/src/enemy_defense.js
@@ -1,0 +1,1 @@
+module.exports.perCharaEnemyDefense = false;

--- a/src/global_const.js
+++ b/src/global_const.js
@@ -732,7 +732,6 @@ var enemyDefenseType = {
     14.0: { "name": "敵防御14.0" },
     15.0: { "name": "敵防御15.0" },
     20.0: { "name": "敵防御20.0" },
-    0.00: { "name": "素敵な防御値" },
 }
 var keyTypes = {
     "totalAttack": "攻撃力(二手技巧無し,ジータさんのみ)",

--- a/src/global_const.js
+++ b/src/global_const.js
@@ -732,6 +732,7 @@ var enemyDefenseType = {
     14.0: { "name": "敵防御14.0" },
     15.0: { "name": "敵防御15.0" },
     20.0: { "name": "敵防御20.0" },
+    0.00: { "name": "素敵な防御値" },
 }
 var keyTypes = {
     "totalAttack": "攻撃力(二手技巧無し,ジータさんのみ)",

--- a/src/profile.js
+++ b/src/profile.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var {Button, FormControl, InputGroup, FormGroup} = require('react-bootstrap');
+var {Button, Checkbox, FormControl, InputGroup, FormGroup} = require('react-bootstrap');
 var intl = require('./translate.js');
 var GlobalConst = require('./global_const.js');
 var TextWithTooltip = GlobalConst.TextWithTooltip;
@@ -193,7 +193,10 @@ var Profile = CreateClass({
             hp: 100,
             remainHP: 100,
             enemyElement: "wind",
+            manualEnemyDefense: false,
+            perCharaEnemyDefense: false,
             enemyDefense: 10.0,
+            enemyDefenseValue: 10.0,
             defenseDebuff: 0.0,
             job: "none",
             sex: "female",
@@ -237,7 +240,23 @@ var Profile = CreateClass({
     handleSelectEvent: function (key, e) {
         // A select type input form is good for onChange
         var newState = this.state;
-        newState[key] = e.target.value;
+        if (e.target.type === "checkbox") {
+            newState[key] = e.target.checked;
+        } else if (key == "enemyDefenseValue" && e.target.value == 0 && !newState.manualEnemyDefense) {
+            newState[key] = e.target.value;
+            newState.manualEnemyDefense = true;
+            newState.defenseDebuff = 0.0;
+            newState.enemyDefense = 10.0;
+        } else if (key == "enemyDefenseValue" && e.target.value != 0 && newState.manualEnemyDefense) {
+            newState[key] = e.target.value;
+            newState.manualEnemyDefense = false;
+            newState.enemyDefense = e.target.value;
+        } else if (key == "enemyDefenseValue") {
+            newState[key] = e.target.value;
+            newState.enemyDefense = newState[key];
+        } else {
+            newState[key] = e.target.value;
+        }
         if (key == "job") {
             newState.DA = Jobs[e.target.value].DaBonus;
             newState.TA = Jobs[e.target.value].TaBonus
@@ -854,28 +873,60 @@ var Profile = CreateClass({
                         </td>
                     </tr>
 
-                    <TextWithTooltip tooltip={intl.translate("敵防御固有値説明", locale)} id={"tooltip-enemy-defense-detail"}>
-                        <tr>
-                            <th className="bg-primary">{intl.translate("敵防御固有値", locale)}</th>
-                            <td><FormControl componentClass="select" value={this.state.enemyDefense}
-                                             onChange={this.handleSelectEvent.bind(this, "enemyDefense")}> {selector[locale].enemydeftypes} </FormControl>
-                            </td>
-                        </tr>
-                    </TextWithTooltip>
-
-                    <TextWithTooltip tooltip={intl.translate("防御デバフ合計説明", locale)} id={"tooltip-defense-debuff-detail"}>
-                        <tr>
-                            <th className="bg-primary">{intl.translate("防御デバフ合計", locale)}</th>
-                                <td>
-                                    <InputGroup>
-                                        <FormControl type="number" min="0" step="5" max="100" value={this.state.defenseDebuff}
-                                            onBlur={this.handleOnBlur}
-                                            onChange={this.handleEvent.bind(this, "defenseDebuff")}/>
-                                        <InputGroup.Addon>%</InputGroup.Addon>
-                                    </InputGroup>
-                                </td>
-                        </tr>
-                    </TextWithTooltip>
+                    {this.state.manualEnemyDefense 
+                     ? 
+                        [
+                            <TextWithTooltip tooltip={intl.translate("敵防御固有値説明", locale)} id={"tooltip-enemy-defense-detail"}>
+                                <tr>
+                                    <th className="bg-primary">{intl.translate("敵防御固有値", locale)}</th>
+                                    <td>
+                                        <FormControl componentClass="select" value={this.state.enemyDefenseValue}
+                                                     onChange={this.handleSelectEvent.bind(this, "enemyDefenseValue")}> {selector[locale].enemydeftypes} </FormControl>
+                                        <Checkbox inline checked={this.state.perCharaEnemyDefense}
+                                                  onChange={this.handleSelectEvent.bind(this, "perCharaEnemyDefense")}>
+                                         <strong>{intl.translate("キャラ特定の敵防御", locale)}</strong>
+                                        </Checkbox>
+                                    </td>
+                                </tr>
+                            </TextWithTooltip>
+,
+                            <TextWithTooltip tooltip={intl.translate("敵防御固有値説明", locale)} id={"tooltip-enemy-defense-2-detail"}>
+                                <tr>
+                                    <th className="bg-primary">{intl.translate("敵防御固有値", locale)}</th>
+                                        <td>
+                                            <FormControl type="number" min="0" step="0.5" value={this.state.enemyDefense}
+                                                onBlur={this.handleOnBlur}
+                                                onChange={this.handleEvent.bind(this, "enemyDefense")}/>
+                                        </td>
+                                </tr>
+                            </TextWithTooltip>
+                        ]
+                     : //------
+                        [
+                            <TextWithTooltip tooltip={intl.translate("敵防御固有値説明", locale)} id={"tooltip-enemy-defense-detail"}>
+                                <tr>
+                                    <th className="bg-primary">{intl.translate("敵防御固有値", locale)}</th>
+                                    <td><FormControl componentClass="select" value={this.state.enemyDefenseValue}
+                                                     onChange={this.handleSelectEvent.bind(this, "enemyDefenseValue")}> {selector[locale].enemydeftypes} </FormControl>
+                                    </td>
+                                </tr>
+                            </TextWithTooltip>
+,
+                            <TextWithTooltip tooltip={intl.translate("防御デバフ合計説明", locale)} id={"tooltip-defense-debuff-detail"}>
+                                <tr>
+                                    <th className="bg-primary">{intl.translate("防御デバフ合計", locale)}</th>
+                                        <td>
+                                            <InputGroup>
+                                                <FormControl type="number" min="0" step="5" max="100" value={this.state.defenseDebuff}
+                                                    onBlur={this.handleOnBlur}
+                                                    onChange={this.handleEvent.bind(this, "defenseDebuff")}/>
+                                                <InputGroup.Addon>%</InputGroup.Addon>
+                                            </InputGroup>
+                                        </td>
+                                </tr>
+                            </TextWithTooltip>
+                        ]
+                    }
 
                     <TextWithTooltip tooltip={intl.translate("ジータさん基礎DA率説明", locale)}
                                      id={"tooltip-player-baseda-detail"}>
@@ -888,6 +939,7 @@ var Profile = CreateClass({
                             </InputGroup></td>
                         </tr>
                     </TextWithTooltip>
+                    
                     <TextWithTooltip tooltip={intl.translate("ジータさん基礎TA率説明", locale)}
                                      id={"tooltip-player-baseta-detail"}>
                         <tr>

--- a/src/profile.js
+++ b/src/profile.js
@@ -4,7 +4,7 @@ var intl = require('./translate.js');
 var GlobalConst = require('./global_const.js');
 var TextWithTooltip = GlobalConst.TextWithTooltip;
 var CreateClass = require('create-react-class');
-
+var EnemyDefense = require('./enemy_defense.js');
 // const
 var zenith = GlobalConst.zenith;
 var zenithDA = GlobalConst.zenithDA;
@@ -196,7 +196,6 @@ var Profile = CreateClass({
             manualEnemyDefense: false,
             perCharaEnemyDefense: false,
             enemyDefense: 10.0,
-            enemyDefenseValue: 10.0,
             defenseDebuff: 0.0,
             job: "none",
             sex: "female",
@@ -242,18 +241,11 @@ var Profile = CreateClass({
         var newState = this.state;
         if (e.target.type === "checkbox") {
             newState[key] = e.target.checked;
-        } else if (key == "enemyDefenseValue" && e.target.value == 0 && !newState.manualEnemyDefense) {
-            newState[key] = e.target.value;
-            newState.manualEnemyDefense = true;
-            newState.defenseDebuff = 0.0;
-            newState.enemyDefense = 10.0;
-        } else if (key == "enemyDefenseValue" && e.target.value != 0 && newState.manualEnemyDefense) {
-            newState[key] = e.target.value;
-            newState.manualEnemyDefense = false;
-            newState.enemyDefense = e.target.value;
-        } else if (key == "enemyDefenseValue") {
-            newState[key] = e.target.value;
-            newState.enemyDefense = newState[key];
+            if (key == 'perCharaEnemyDefense') {
+                EnemyDefense.perCharaEnemyDefense = this.state.perCharaEnemyDefense;
+            } else if (key == 'manualEnemyDefense') {
+                newState.enemyDefense = newState.enemyDefense in GlobalConst.enemyDefenseType ? newState.enemyDefense : 10.0;
+           }
         } else {
             newState[key] = e.target.value;
         }
@@ -873,60 +865,48 @@ var Profile = CreateClass({
                         </td>
                     </tr>
 
-                    {this.state.manualEnemyDefense 
-                     ? 
-                        [
-                            <TextWithTooltip tooltip={intl.translate("敵防御固有値説明", locale)} id={"tooltip-enemy-defense-detail"}>
-                                <tr>
-                                    <th className="bg-primary">{intl.translate("敵防御固有値", locale)}</th>
-                                    <td>
-                                        <FormControl componentClass="select" value={this.state.enemyDefenseValue}
-                                                     onChange={this.handleSelectEvent.bind(this, "enemyDefenseValue")}> {selector[locale].enemydeftypes} </FormControl>
-                                        <Checkbox inline checked={this.state.perCharaEnemyDefense}
-                                                  onChange={this.handleSelectEvent.bind(this, "perCharaEnemyDefense")}>
-                                         <strong>{intl.translate("キャラ特定の敵防御", locale)}</strong>
-                                        </Checkbox>
-                                    </td>
-                                </tr>
-                            </TextWithTooltip>
-,
-                            <TextWithTooltip tooltip={intl.translate("敵防御固有値説明", locale)} id={"tooltip-enemy-defense-2-detail"}>
-                                <tr>
-                                    <th className="bg-primary">{intl.translate("敵防御固有値", locale)}</th>
-                                        <td>
-                                            <FormControl type="number" min="0" step="0.5" value={this.state.enemyDefense}
-                                                onBlur={this.handleOnBlur}
-                                                onChange={this.handleEvent.bind(this, "enemyDefense")}/>
-                                        </td>
-                                </tr>
-                            </TextWithTooltip>
-                        ]
-                     : //------
-                        [
-                            <TextWithTooltip tooltip={intl.translate("敵防御固有値説明", locale)} id={"tooltip-enemy-defense-detail"}>
-                                <tr>
-                                    <th className="bg-primary">{intl.translate("敵防御固有値", locale)}</th>
-                                    <td><FormControl componentClass="select" value={this.state.enemyDefenseValue}
-                                                     onChange={this.handleSelectEvent.bind(this, "enemyDefenseValue")}> {selector[locale].enemydeftypes} </FormControl>
-                                    </td>
-                                </tr>
-                            </TextWithTooltip>
-,
-                            <TextWithTooltip tooltip={intl.translate("防御デバフ合計説明", locale)} id={"tooltip-defense-debuff-detail"}>
-                                <tr>
-                                    <th className="bg-primary">{intl.translate("防御デバフ合計", locale)}</th>
-                                        <td>
-                                            <InputGroup>
-                                                <FormControl type="number" min="0" step="5" max="100" value={this.state.defenseDebuff}
-                                                    onBlur={this.handleOnBlur}
-                                                    onChange={this.handleEvent.bind(this, "defenseDebuff")}/>
-                                                <InputGroup.Addon>%</InputGroup.Addon>
-                                            </InputGroup>
-                                        </td>
-                                </tr>
-                            </TextWithTooltip>
-                        ]
-                    }
+                    
+                    <TextWithTooltip tooltip={intl.translate("敵防御固有値説明", locale)} id={"tooltip-enemy-defense-detail"}>
+                        <tr>
+                            <th className="bg-primary">
+                                {intl.translate("敵防御固有値", locale)}
+                                <Checkbox inline checked={this.state.manualEnemyDefense}
+                                          onChange={this.handleSelectEvent.bind(this, "manualEnemyDefense")}>
+                                 <strong>{intl.translate("素敵な防御値", locale)}</strong>
+                                </Checkbox>
+                            </th>
+                            <td>
+                                <Checkbox inline checked={this.state.perCharaEnemyDefense}
+                                          onChange={this.handleSelectEvent.bind(this, "perCharaEnemyDefense")}>
+                                 <strong>{intl.translate("キャラ特定の敵防御", locale)}</strong>
+                                </Checkbox>
+                                {this.state.manualEnemyDefense
+                                 ?
+                                    <FormControl type="number" min="0" step="0.5" value={this.state.enemyDefense}
+                                                 onBlur={this.handleOnBlur}
+                                                 onChange={this.handleEvent.bind(this, "enemyDefense")}/>
+                                 :
+                                    <FormControl componentClass="select" value={this.state.enemyDefense}
+                                                 onChange={this.handleSelectEvent.bind(this, "enemyDefense")}> {selector[locale].enemydeftypes} </FormControl>
+                                }
+                                
+                            </td>
+                        </tr>
+                    </TextWithTooltip>
+
+                    <TextWithTooltip tooltip={intl.translate("防御デバフ合計説明", locale)} id={"tooltip-defense-debuff-detail"}>
+                        <tr>
+                            <th className="bg-primary">{intl.translate("防御デバフ合計", locale)}</th>
+                                <td>
+                                    <InputGroup>
+                                        <FormControl type="number" min="0" step="5" max="100" value={this.state.defenseDebuff}
+                                            onBlur={this.handleOnBlur}
+                                            onChange={this.handleEvent.bind(this, "defenseDebuff")}/>
+                                        <InputGroup.Addon>%</InputGroup.Addon>
+                                    </InputGroup>
+                                </td>
+                        </tr>
+                    </TextWithTooltip>
 
                     <TextWithTooltip tooltip={intl.translate("ジータさん基礎DA率説明", locale)}
                                      id={"tooltip-player-baseda-detail"}>

--- a/src/translate.js
+++ b/src/translate.js
@@ -3229,6 +3229,16 @@ var multiLangData = {
         "ja": "20.0 (プロトバハムートHL/ルシファーH)",
         "zh": "20.0 (Proto Baha HL/Lucilius H)",
 	},
+    "素敵な防御値": {
+        "en": "Manual Input",
+        "ja": "素敵な防御値",
+        "zh": "Manual Input",
+    },
+    "キャラ特定の敵防御": {
+        "en": "Character Specific Enemy Defense",
+        "ja": "キャラ特定の敵防御",
+        "zh": "Character Specific Enemy Defense",
+    },
     // chart sort key
     "ジータさん残りHP": {
         "en": "Player Remain HP",

--- a/src/translate.js
+++ b/src/translate.js
@@ -3230,9 +3230,9 @@ var multiLangData = {
         "zh": "20.0 (Proto Baha HL/Lucilius H)",
 	},
     "素敵な防御値": {
-        "en": "Manual Input",
-        "ja": "素敵な防御値",
-        "zh": "Manual Input",
+        "en": "\nManual Input",
+        "ja": "\n素敵な防御値",
+        "zh": "\nManual Input",
     },
     "キャラ特定の敵防御": {
         "en": "Character Specific Enemy Defense",


### PR DESCRIPTION
_#147 seems to be a "cleaner" way? but from what understood there were compatibility issues._

- In this branch/PR,
    - "replace" DEF Debuff row with value.
    - could also have a _Check box_ to switch between "modes" instead

- [x] enable per character enemy defense. _(yes, i'm aware about that the check box is only in 'manual mode')_
  - this could be very useful for doing OTK setups/etc...
  - I have not added this yet, since the _old_ implementation ([here](http://yasha-motocal.herokuapp.com/), check below for more details.) uses an exported _(propery?/variable?)_  in GlobalConst to "communicate" between `profile.js` and `chara.js`. which didn't seems the 'best' way to do it.

<hr>

something like this: _this is not how it is implemented in the link. (it's more "wrong" way. same concept)_
`global_const.js`
```js
module.exports.perCharaEnemyDefense = undefined; //not necessary. could be false to have "cleaner" look.
```
`profile.js`
```js
if (e.target.type === "checkbox") {
    newState[key] = e.target.checked;
    if (key == 'perCharaEnemyDefense') {
        GlobalConst.perCharaEnemyDefense = newState[key];
    }
}
```
`chara.js`
```js
{GlobalConst.perCharaEnemyDefense === true //to ignore undefined/other possible values.
 ? <tr>
    <th className="bg-primary">{intl.translate("敵防御固有値", locale)}</th>
    <td><FormControl type="number" min="1" step="0.5" value={this.state.enemyDefense}
            onBlur={this.handleOnBlur.bind(this, "enemyDefense")}
            onChange={this.handleEvent.bind(this, "enemyDefense")} />
    </td>
</tr>
 : null
}
```