### PR TITLE
Fix context in beforeEach call (unittest)

### DIFF
--- a/src/supplemental.test.js
+++ b/src/supplemental.test.js
@@ -4,8 +4,10 @@ describe("#calcSupplementalDamage", () => {
     // generate temporary vals: [0, 0, 0, 0]
     const INITIAL_VALS = (length=4, value=0) => (new Array(length)).fill(value);
 
+    let supplementalDamageArray;
+
     beforeEach(() => {
-        this.supplementalDamageArray = {
+        supplementalDamageArray = {
             "test-buff-a": {
                 damage: 10,
                 damageWithoutCritical: 10,
@@ -25,14 +27,12 @@ describe("#calcSupplementalDamage", () => {
   
     describe("#calcOthersDamage", () => {
         it("test single hit supplemental damage", () => {
-            let {supplementalDamageArray} = this;
             let vals = supplemental.calcOthersDamage(supplementalDamageArray, INITIAL_VALS());
             expect(vals.length).toBe(4);
             expect(vals).toEqual([30, 30, 300, 500]);
         });
   
         it("test hp based supplemental damage", () => {
-            let {supplementalDamageArray} = this;
             supplementalDamageArray['test-buff-a']['type'] = 'hp_based';
             supplementalDamageArray['test-buff-a']['threshold'] = 0.80;
             
@@ -55,7 +55,6 @@ describe("#calcSupplementalDamage", () => {
         });
       
         it("test unknown type is ignored", () => {
-            let {supplementalDamageArray} = this;
             supplementalDamageArray['test-buff-a']['type'] = undefined;
             supplementalDamageArray['test-buff-b']['type'] = 'othr'; // assume typo case       
             
@@ -78,7 +77,6 @@ describe("#calcSupplementalDamage", () => {
 
     describe("#calcThirdHitDamage", () => {
         it("test third hit supplemental damage", () => {
-            let {supplementalDamageArray} = this;
             supplementalDamageArray['test-buff-a']['type'] = 'third_hit';
  
             // default expectedTurn: 1
@@ -100,7 +98,6 @@ describe("#calcSupplementalDamage", () => {
   
     // xit -> Skip test, `test.skip` for Jest
     xit("test unknown report", () => {
-        let {supplementalDamageArray} = this;
         supplementalDamageArray["test-buff-a"]["type"] = "unknown";
       
         let vals = supplemental._calcDamage(["unknown"], supplementalDamageArray, INITIAL_VALS());
@@ -113,7 +110,7 @@ describe("#calcSupplementalDamage", () => {
 
 describe("#collectSkillInfo", () => {
     beforeEach(() => {
-        this.supplementalDamageArray = {
+        supplementalDamageArray = {
             "D": { // for checking sort headers
                 damage: 10,
                 type: "other", 
@@ -157,7 +154,6 @@ describe("#collectSkillInfo", () => {
     // https://jestjs.io/docs/ja/api#testeachtable-name-fn-timeout
     // (Jasmine in codepen.io did not support the same method)
     it("test damageArray remainHP 100%,50%", () => {
-        let {supplementalDamageArray} = this;
         const toKey = ([key, type, extraValue]) => key;
       
         let supplementalInfo = supplemental.collectSkillInfo(supplementalDamageArray, {remainHP: 1.00});


### PR DESCRIPTION
This was happen by the difference between Jasmin(CodePen) and Jest(Motocal)

It's repored in official jest issue https://github.com/facebook/jest/issues/3553
Jest fixed the re-use of `this` context as bug.
(it's actually implicitly context binding to use `this` in test code)
so Jasmin's test code will not work in Jest.

This patch is required in #201

Here is current #201 test result, it changes babel setting for jest (test only change)
![jest-error](https://user-images.githubusercontent.com/45387555/59604938-7ea62000-9148-11e9-8b3c-5912622dd633.PNG)

This patch only change the test code, that just moving the variable context/scope.
No effects to Motocal main code at all. So it's safe to Approve if Travis status shows green.

----

@h-yasha just mention for update unit test info
my test code not work in Jest (maybe in future when library updated)
~~we can't write ` let {variable} = this;` in Jest code anymore.~~
we should not use `this` context variable in test code.