### PR TITLE
Minor Updates

### DIFF
--- a/src/notice.js
+++ b/src/notice.js
@@ -217,19 +217,20 @@ var Notice = CreateClass({
 
                 <h3>Tips</h3>
                     <li className="list-group-item list-group-item-info">メイン武器等1本は必ず入れたい武器がある時は最小本数を入力して下さい。</li>
-                    <li className="list-group-item list-group-item-info">スキル効果は上部「表示する項目を選択」 → 「キャラ情報・スキル合計値」 → 「スキル合計」で確認できます。(加護適応済みの値)</li>
-                    <li className="list-group-item list-group-item-info">奥義編成の理想を知りたい場合は、ジータタブ「より細かい設定」からチェイン数4選択後、編成一覧上の優先項目から「奥義+チェンバダメージ」を選択して下さい。</li>
+                    <li className="list-group-item list-group-item-info">スキル効果は上部「表示する項目を選択」 → 「キャラ情報・スキル合計値」 → 「スキル合計」で確認できます。(加護適応済みの値)(バフ・サポアビも含む)</li>
+                    <li className="list-group-item list-group-item-info">奥義編成の理想を知りたい場合は、ジータタブ「より細かい設定」からチェイン数4選択後、編成一覧上の「優先項目」から「奥義+チェンバダメージ」を選択して下さい。</li>
                     <li className="list-group-item list-group-item-info">上部「背水渾身グラフを開く」を選択するには、その前に編成右側からグラフ「追加」を選択する必要があります。</li>
 
                 <h3>注記</h3>
                 <ul className="list-group">
-                    <li className="list-group-item list-group-item-info">情報求: Rank200辺りからの基礎攻撃力計算式、キャラの基礎連撃率(現在対応済リストは<a href="https://github.com/MotocalDevelopers/motocal/blob/master/scripts/chara_data_converter.py" target="_blank">こちら</a>の100行辺りから。デフォルト値はDA7%,TA3%)、グラブルの各種計算式まとめ。</li>
-                    <li className="list-group-item list-group-item-info">未対応: ゲージ200%キャラ、バフの効果ターン・リキャスト、経過ターンで増減するスキル、虚空武器の与ダメージ上昇効果。</li>
+                    <li className="list-group-item list-group-item-info"><font color="#6c2c2f">情報求:</font> 武器やキャラのステータスズレ、Rank200辺りからの基礎攻撃力増加量、キャラの基礎連撃率(現在対応済リストは<a href="https://github.com/MotocalDevelopers/motocal/blob/master/scripts/chara_data_converter.py" target="_blank">こちら</a>の100行辺りから。デフォルト値はDA7%,TA3%)、各種計算式の検証データ。</li>
+                    <li className="list-group-item list-group-item-info"><font color="#6c2c2f">未対応:</font> ゲージ200%キャラ、バフの効果ターン・リキャスト、経過ターンで増減するスキル、多数の英雄武器の効果。</li>
                     <li className="list-group-item list-group-item-info">編成データを読み込むとホワイトアウトしてしまう場合があります。恐らく仕様変更が原因なので、新しく編成を作り直すか対策パッチをお待ち下さい。</li>
+                    <li className="list-group-item list-group-item-info">乱数や技巧によるブレがあるため、実際のダメージとは多少異なる可能性があります。</li>
                     <li className="list-group-item list-group-item-info">キャラの基礎連撃率やサポアビ等が追加されても既存の編成データは自動で更新されません。キャラの入れ直しをお願いします。</li>
-                    <li className="list-group-item list-group-item-info">基本的に考えうる全ての編成のデータを計算しますが、計算数が1024通りを超えた場合は合計本数10本の編成のみ算出・比較します。(計算量削減のため)</li>
+                    <li className="list-group-item list-group-item-info">基本的に考えうる全ての武器編成パターンを計算しますが、計算数が1024通りを超えた場合は合計本数10本の編成のみ算出・比較します。(計算量削減のため)</li>
                     <li className="list-group-item list-group-item-info">パーティ全体の残HP指定と個別の残HP指定のうち、低い方を適用して背水値を計算します。(背水キャラ運用用)</li>
-                    <li className="list-group-item list-group-item-info">スキル効果表示「別枠バフ」は複数ある場合乗算後の数字が出てきます。</li>
+                    <li className="list-group-item list-group-item-info">別枠バフが複数ある場合、スキル効果表示には乗算後の値が出てきます。</li>
                     <li className="list-group-item list-group-item-info">弱体耐性率は目安です。あまり参考にしないで下さい。</li>
                     <li className="list-group-item list-group-item-info">"パーティ平均〇〇"にはSubに配置したキャラも含まれます。</li>
                 </ul>
@@ -321,7 +322,7 @@ var Notice = CreateClass({
                         href="https://twitter.com/search?f=tweets&q=from%3A%40agavenighto%20%E6%A4%9C%E8%A8%BC&src=typd" target="_blank"> @agavenighto さんの方陣破壊(小)、方陣乱舞(中)検証結果 </a>
                     </li>
                     <li className="list-group-item"><a
-                        href="https://twitter.com/agavenighto/status/1091626790714404865" target="_blank"> 神ゲー攻略 - 防御値の解説と敵の防御値一覧  </a>
+                        href="https://twitter.com/Hecate_mk2/status/1119458102934269953" target="_blank"> @Hecate_mk2 さんの防御値一覧 </a>
                     </li>
                     <li className="list-group-item"><a
                         href="https://docs.google.com/spreadsheets/d/1kea2IL6wLNbw4RNUcrrxMTpoIdlXU13pYOzBXjgoBbs/edit#gid=199555968" target="_blank"> ポキールさんのグラブル検証置き場 - 奥義性能 </a>
@@ -330,16 +331,19 @@ var Notice = CreateClass({
                         href="https://xn--bck3aza1a2if6kra4ee0hf.gamewith.jp/" target="_blank"> Gamewithさんの諸々のスキル効果量検証結果 </a>
                     </li>
                     <li className="list-group-item"><a
-                        href="http://gbf-verification.blog.jp/" target="_blank"> グラブル検証Logさんの諸々のスキル効果量検証結果 </a>
+                        href="http://gbf-verification.blog.jp/" target="_blank"> グラブル検証Logさんの諸々の検証結果 </a>
                     </li>
                     <li className="list-group-item"><a
                         href="https://twitter.com/Hecate_mk2" target="_blank"> @Hecate_mk2 さんの諸々の検証結果 </a>
                     </li>
                     <li className="list-group-item"><a
-                        href="https://docs.google.com/spreadsheets/d/1SUhqwiq3UC7ba7jh22s0mhHJ_33Zi443aRywe-CmURQ/edit#gid=321585253" target="_blank"> スフレさんの背水・渾身検証結果 </a>
+                        href="https://docs.google.com/spreadsheets/d/1SUhqwiq3UC7ba7jh22s0mhHJ_33Zi443aRywe-CmURQ/edit#gid=321585253" target="_blank"> スフレさんのLB背水・渾身検証結果 </a>
                     </li>
                     <li className="list-group-item"><a
                         href="https://twitter.com/i/moments/1040200666260459520" target="_blank"> @Duran_grablu さんの方陣技巧検証結果 </a>
+                    </li>
+                    <li className="list-group-item"><a
+                        href="https://twitter.com/CryingOfLot307/status/1134475816065069056" target="_blank"> @CryingOfLot307 さんの技巧中Slv15検証結果 </a>
                     </li>
                     <li className="list-group-item"><a
                         href="https://twitter.com/search?f=tweets&q=from%3A%40usa_akasa%20%E6%A4%9C%E8%A8%BC&src=typd" target="_blank"> @usa_akasa さんの基礎連撃率検証結果 </a>
@@ -1121,11 +1125,11 @@ var Notice = CreateClass({
                             <td>4.6</td>
                             <td>4.8</td>
                             <td>5.0</td>
-                            <td>5.2</td>
-                            <td>5.4</td>
+                            <td>5.3</td>
                             <td>5.6</td>
-                            <td>5.8</td>
-                            <td>6.0</td>
+                            <td>5.9</td>
+                            <td>6.2</td>
+                            <td>6.5</td>
                         </tr>
                         <tr>
                             <td>技巧(大)</td>

--- a/src/notice.js
+++ b/src/notice.js
@@ -21,6 +21,10 @@ var Notice = CreateClass({
                        header={<span><Glyphicon glyph="chevron-right"/>&nbsp;Update Logs</span>}>
                     <ChangeLog className="list-group" length={10} step={20} buttonText={intl.translate("次の{step}件を表示", locale)}>
 
+                        <li className="list-group-item list-group-item-info">{intl.translate("notice-20190618-1", locale)}</li>
+                        <li className="list-group-item list-group-item-info">{intl.translate("notice-20190617-1", locale)}</li>
+                        <li className="list-group-item list-group-item-info">{intl.translate("notice-20190615-1", locale)}</li>
+                        <li className="list-group-item list-group-item-info">{intl.translate("notice-20190608-1", locale)}</li>
                         <li className="list-group-item list-group-item-info">{intl.translate("notice-20190606-1", locale)}</li>
                         <li className="list-group-item list-group-item-info">{intl.translate("notice-20190528-1", locale)}</li>
                         <li className="list-group-item list-group-item-info">{intl.translate("notice-20190518-1", locale)}</li>

--- a/src/profile.js
+++ b/src/profile.js
@@ -412,27 +412,27 @@ var Profile = CreateClass({
                                 </td>
                             </tr>,
                             <tr key="personalOugiDamageBuff">
-                                <th className="bg-primary">{intl.translate("奥義ダメージUP", locale)}</th>
+                                <th className="bg-primary">{intl.translate("奥義ダメージバフ", locale)}</th>
                                 <td><InputGroup><FormControl componentClass="select" value={this.state.personalOugiDamageBuff}
                                                              onChange={this.handleSelectEvent.bind(this, "personalOugiDamageBuff")}>{selector.buffLevel}</FormControl><InputGroup.Addon>%</InputGroup.Addon>
                                 </InputGroup></td>
                             </tr>,
                             <tr key="personalOugiGageBuff">
-                                <th className="bg-primary">{intl.translate("奥義ゲージ上昇率アップ", locale)}</th>
+                                <th className="bg-primary">{intl.translate("奥義ゲージ上昇量バフ", locale)}</th>
                                 <td><InputGroup><FormControl componentClass="select" value={this.state.personalOugiGageBuff}
                                                  onChange={this.handleSelectEvent.bind(this, "personalOugiGageBuff")}>{selector.buffLevel}</FormControl>
                                 <InputGroup.Addon>%</InputGroup.Addon>
                                 </InputGroup></td>
                             </tr>,
                             <tr key="personalDamageLimit">
-                                <th className="bg-primary">{intl.translate("ダメージ上限アップ", locale)}</th>
+                                <th className="bg-primary">{intl.translate("ダメージ上限バフ", locale)}</th>
                                 <td><InputGroup><FormControl componentClass="select" value={this.state.personalDamageLimitBuff}
                                                  onChange={this.handleSelectEvent.bind(this, "personalDamageLimitBuff")}>{selector.buffLevel}</FormControl>
                                 <InputGroup.Addon>%</InputGroup.Addon>
                                 </InputGroup></td>
                             </tr>,
                             <tr key="personalOugiDamageLimit">
-                                <th className="bg-primary">{intl.translate("奥義ダメージ上限アップ", locale)}</th>
+                                <th className="bg-primary">{intl.translate("奥義ダメージ上限バフ", locale)}</th>
                                 <td><InputGroup><FormControl componentClass="select" value={this.state.personalOugiDamageLimitBuff}
                                                  onChange={this.handleSelectEvent.bind(this, "personalOugiDamageLimitBuff")}>{selector.buffLevel}</FormControl>
                                 <InputGroup.Addon>%</InputGroup.Addon>
@@ -648,7 +648,7 @@ var Profile = CreateClass({
 
                     <tr>
                         <td colSpan="2">
-                            <strong>{intl.translate("パーティバフタイトル", locale)}</strong><span className="input-suggest">*</span>
+                            <strong>{intl.translate("パーティバフタイトル", locale)}</strong>
                             <p>{intl.translate("パーティバフ説明", locale)}</p>
                         </td>
                     </tr>
@@ -756,7 +756,7 @@ var Profile = CreateClass({
                     <TextWithTooltip tooltip={intl.translate("奥義ダメージ上限アップ説明", locale)}
                                      id={"tooltip-ougidamagebuff-detail"}>
                         <tr>
-                            <th className="bg-primary">{intl.translate("奥義ダメージUP", locale)}</th>
+                            <th className="bg-primary">{intl.translate("奥義ダメージバフ", locale)}</th>
                             <td>
                                 <InputGroup>
                                     <FormControl componentClass="select" value={this.state.ougiDamageBuff}
@@ -795,7 +795,7 @@ var Profile = CreateClass({
                     <TextWithTooltip tooltip={intl.translate("奥義ゲージ上昇率アップ説明", locale)}
                                      id={"tooltip-ougigagebuff-detail"}>
                         <tr>
-                            <th className="bg-primary">{intl.translate("奥義ゲージ上昇率アップ", locale)}</th>
+                            <th className="bg-primary">{intl.translate("奥義ゲージ上昇量バフ", locale)}</th>
                             <td>
                                 <InputGroup>
                                     <FormControl componentClass="select" value={this.state.ougiGageBuff}
@@ -823,7 +823,7 @@ var Profile = CreateClass({
                     <TextWithTooltip tooltip={intl.translate("ダメージ上限アップ説明", locale)}
                                      id={"tooltip-damage-limit-buff-detail"}>
                         <tr>
-                            <th className="bg-primary">{intl.translate("ダメージ上限アップ", locale)}</th>
+                            <th className="bg-primary">{intl.translate("ダメージ上限バフ", locale)}</th>
                             <td>
                                 <InputGroup>
                                     <FormControl componentClass="select" value={this.state.damageLimitBuff}
@@ -837,7 +837,7 @@ var Profile = CreateClass({
                     <TextWithTooltip tooltip={intl.translate("奥義ダメージ上限アップ説明", locale)}
                                      id={"tooltip-ougi-damage-limit-buff-detail"}>
                         <tr>
-                            <th className="bg-primary">{intl.translate("奥義ダメージ上限アップ", locale)}</th>
+                            <th className="bg-primary">{intl.translate("奥義ダメージ上限バフ", locale)}</th>
                             <td>
                                 <InputGroup>
                                     <FormControl componentClass="select" value={this.state.ougiDamageLimitBuff}

--- a/src/profile.js
+++ b/src/profile.js
@@ -290,7 +290,7 @@ var Profile = CreateClass({
                     <TextWithTooltip tooltip={intl.translate("ランク説明", locale)} id={"tooltip-rank-detail"}>
                         <tr>
                             <th className="bg-primary">Rank<span className="input-suggest">*</span></th>
-                            <td><FormControl type="number" min="1" max="225" value={this.state.rank}
+                            <td><FormControl type="number" min="1" max="300" value={this.state.rank}
                                              onBlur={this.handleOnBlur} onChange={this.handleEvent.bind(this, "rank")}/>
                             </td>
                         </tr>
@@ -781,13 +781,13 @@ var Profile = CreateClass({
                         </tr>
                     </TextWithTooltip>
 
-                    <TextWithTooltip tooltip={intl.translate("supplementalDamageBuff-tooltip", locale)}
+                    <TextWithTooltip tooltip={intl.translate("supplementalDamageBuff-tooltip", locale)} //与ダメージ上昇効果バフ
                                      id={"tooltip-supplementalDamageBuff-detail"}>
                         <tr>
                             <th className="bg-primary">{intl.translate("supplementalDamageBuff", locale)}</th>
                             <td>
-                                <FormControl type="number" value={this.state.supplementalDamageBuff}
-                                             onBlur={this.handleOnBlur} onChange={this.handleSelectEvent.bind(this, "supplementalDamageBuff")}></FormControl>
+                                <FormControl type="number" min="0" step="1000" max="100000" value={this.state.supplementalDamageBuff}
+                                             onBlur={this.handleOnBlur} onChange={this.handleEvent.bind(this, "supplementalDamageBuff")}></FormControl>
                             </td>
                         </tr>
                     </TextWithTooltip>

--- a/src/profile.js
+++ b/src/profile.js
@@ -325,7 +325,7 @@ var Profile = CreateClass({
                     </TextWithTooltip>
 
                     <tr>
-                        <th className="bg-primary">{intl.translate("ジータさん性別", locale)}<span className="input-suggest">*</span></th>
+                        <th className="bg-primary">{intl.translate("ジータさん性別", locale)}</th>
                         <td><FormControl componentClass="select" value={this.state.sex}
                                          onChange={this.handleSelectEvent.bind(this, "sex")}> {selector[locale].sexes} </FormControl>
                         </td>
@@ -451,7 +451,7 @@ var Profile = CreateClass({
                     <TextWithTooltip tooltip={intl.translate("マスボATK説明", locale)} id={"tooltip-masterbonus-atk-detail"}>
                         <tr>
                             <th className="bg-primary">
-                                {intl.translate("マスボATK", locale)}<span className="input-suggest">*</span>
+                                {intl.translate("マスボATK", locale)}
                             </th>
                             <td>
                                 <InputGroup>
@@ -481,7 +481,7 @@ var Profile = CreateClass({
                     <TextWithTooltip tooltip={intl.translate("マスボDA説明", locale)} id={"tooltip-masterbonus-da-detail"}>
                         <tr>
                             <th className="bg-primary">
-                                {intl.translate("マスボDA", locale)}<span className="input-suggest">*</span>
+                                {intl.translate("マスボDA", locale)}
                             </th>
                             <td>
                                 <InputGroup>
@@ -496,7 +496,7 @@ var Profile = CreateClass({
                     <TextWithTooltip tooltip={intl.translate("マスボTA説明", locale)} id={"tooltip-masterbonus-ta-detail"}>
                         <tr>
                             <th className="bg-primary">
-                                {intl.translate("マスボTA", locale)}<span className="input-suggest">*</span>
+                                {intl.translate("マスボTA", locale)}
                             </th>
                             <td>
                                 <InputGroup>
@@ -511,7 +511,7 @@ var Profile = CreateClass({
                     <TextWithTooltip tooltip={intl.translate("マスボダメ上限説明", locale)} id={"tooltip-masterbonus-damagelimit-detail"}>
                         <tr>
                             <th className="bg-primary">
-                                {intl.translate("マスボダメ上限", locale)}<span className="input-suggest">*</span>
+                                {intl.translate("マスボダメ上限", locale)}
                             </th>
                             <td>
                                 <InputGroup>
@@ -531,7 +531,7 @@ var Profile = CreateClass({
                     </tr>
 
                     <tr>
-                        <th className="bg-primary">{intl.translate("LB 攻撃力", locale)}<span className="input-suggest">*</span></th>
+                        <th className="bg-primary">{intl.translate("LB 攻撃力", locale)}</th>
                         <td><FormControl componentClass="select" value={this.state.zenithAttackBonus}
                                          onChange={this.handleSelectEvent.bind(this, "zenithAttackBonus")}>{selector.zenithAttack} </FormControl>
                         </td>
@@ -553,7 +553,7 @@ var Profile = CreateClass({
 
                     <TextWithTooltip tooltip={intl.translate("LB DAの説明", locale)} id={"tooltip-da-zenith-detail"}>
                         <tr>
-                            <th className="bg-primary">{intl.translate("LB DA", locale)}<font color="#ffff00">*</font></th>
+                            <th className="bg-primary">{intl.translate("LB DA", locale)}</th>
                             <td><FormControl componentClass="select" value={this.state.zenithDABonus}
                                              onChange={this.handleSelectEvent.bind(this, "zenithDABonus")}> {this.props.zenithDABonuses[locale]} </FormControl>
                             </td>
@@ -562,7 +562,7 @@ var Profile = CreateClass({
 
                     <TextWithTooltip tooltip={intl.translate("LB TAの説明", locale)} id={"tooltip-ta-zenith-detail"}>
                         <tr>
-                            <th className="bg-primary">{intl.translate("LB TA", locale)}<font color="#ffff00">*</font></th>
+                            <th className="bg-primary">{intl.translate("LB TA", locale)}</th>
                             <td><FormControl componentClass="select" value={this.state.zenithTABonus}
                                              onChange={this.handleSelectEvent.bind(this, "zenithTABonus")}> {this.props.zenithTABonuses[locale]} </FormControl>
                             </td>
@@ -571,7 +571,7 @@ var Profile = CreateClass({
 
                     <TextWithTooltip tooltip={intl.translate("LB ダメージ上限UPの説明", locale)} id={"tooltip-ta-zenith-detail"}>
                         <tr>
-                            <th className="bg-primary">{intl.translate("LB ダメージ上限UP", locale)}<font color="#ffff00">*</font></th>
+                            <th className="bg-primary">{intl.translate("LB ダメージ上限UP", locale)}</th>
                             <td><FormControl componentClass="select" value={this.state.zenithDamageLimitBonus}
                                              onChange={this.handleSelectEvent.bind(this, "zenithDamageLimitBonus")}> {this.props.zenithDamageLimitBonuses[locale]} </FormControl>
                             </td>
@@ -580,7 +580,7 @@ var Profile = CreateClass({
 
                     <TextWithTooltip tooltip={intl.translate("LB 奥義の説明", locale)} id={"tooltip-ougidamage-zenith-detail"}>
                         <tr>
-                            <th className="bg-primary">{intl.translate("LB 奥義", locale)}<font color="#ffff00">*</font></th>
+                            <th className="bg-primary">{intl.translate("LB 奥義", locale)}</th>
                             <td><FormControl componentClass="select" value={this.state.zenithOugiDamageBonus}
                                              onChange={this.handleSelectEvent.bind(this, "zenithOugiDamageBonus")}> {this.props.zenithOugiDamageBonuses[locale]} </FormControl>
                             </td>
@@ -648,7 +648,7 @@ var Profile = CreateClass({
 
                     <tr>
                         <td colSpan="2">
-                            <strong>{intl.translate("パーティバフタイトル", locale)}</strong>
+                            <strong>{intl.translate("パーティバフタイトル", locale)}</strong><span className="input-suggest">*</span>
                             <p>{intl.translate("パーティバフ説明", locale)}</p>
                         </td>
                     </tr>
@@ -866,7 +866,7 @@ var Profile = CreateClass({
 
                     <TextWithTooltip tooltip={intl.translate("防御デバフ合計説明", locale)} id={"tooltip-defense-debuff-detail"}>
                         <tr>
-                            <th className="bg-primary">{intl.translate("防御デバフ合計", locale)}</th>
+                            <th className="bg-primary">{intl.translate("防御デバフ合計", locale)}<span className="input-suggest">*</span></th>
                                 <td>
                                     <InputGroup>
                                         <FormControl type="number" min="0" step="5" max="100" value={this.state.defenseDebuff}

--- a/src/translate.js
+++ b/src/translate.js
@@ -3880,9 +3880,29 @@ var multiLangData = {
         "zh": "2019/05/28: Added new weapons and characters, and new normal critical calculation, and Over Masterys. and Soldier.",
     },
     "notice-20190606-1": {
-        "en": "06/06/2019: Added new weapons and characters, Character Balance Patch.",
-        "ja": "2019/06/06: 武器とキャラ追加。キャラバランスパッチ。",
-        "zh": "2019/06/06: Added new weapons and characters, Character Balance Patch.",
+        "en": "06/06/2019: Added new weapons and characters, Character Balance Patch, Hollowsky/Dark opus weapon limit (1 per grid). Updated critical(M) Slv15 effect size to 6.5.",
+        "ja": "2019/06/06: 武器とキャラ追加。キャラ調整アプデ対応。虚空/終末武器が1編成に1つしか入らないように制限。技巧中Slv15の効果量を6.5に変更。",
+        "zh": "2019/06/06: Added new weapons and characters, Character Balance Patch, Hollowsky/Dark opus weapon limit (1 per grid). Updated critical(M) Slv15 effect size to 6.5.",
+    },
+    "notice-20190608-1": {
+        "en": "08/06/2019: Added Wedding Rings to Characters, Plus bonus of character, ChiretsuSenwaku skill. Fixed Vania favorite weapon.",
+        "ja": "2019/06/08: 久遠の指輪対応。キャラバランスパッチ。キャラのプラスボーナス対応。スキル「地裂の煽惑・参」追加。ヴァンピィ得意武器修正。",
+        "zh": "2019/06/08: Added Wedding Rings to Characters, Plus bonus of character, ChiretsuSenwaku skill. Fixed Vania favorite weapon.",
+    },
+    "notice-20190615-1": {
+        "en": "15/06/2019: Added Hollowsky weapons skill2, supplemental damage skill/support, Translation for Characters Support Abilities.",
+        "ja": "2019/06/15: 与ダメ上昇対応(虚空武器スキル、サポアビ、バフ欄)。サポアビ英訳対応。暴君70%制限対応。",
+        "zh": "2019/06/15: Added Hollowsky weapons skill2, supplemental damage skill/support, Translation for Characters Support Abilities.",
+    },
+    "notice-20190617-1": {
+        "en": "17/06/2019: Added Support stamina weapon/Character skills, Elemental Resistance, Uplift. Changed Lily support ability by game update.",
+        "ja": "2019/06/17: メイン装備時渾身スキル/渾身サポアビ対応。敵非有利耐性欄追加。高揚バフ欄追加。リリィのサポアビ変更アプデ対応。",
+        "zh": "2019/06/17: Added Support stamina weapon/Character skills, Elemental Resistance, Uplift. Changed Lily support ability by game update.",
+    },
+    "notice-20190618-1": {
+        "en": "06/06/2019: Added Recent uncaps, Color for upper limit when you display DA/TA skill amount, Character LB of ougiDamage, ougiDamageLimit, ougiGageBuff",
+        "ja": "2019/06/06: 武器上限開放対応。DA/TAスキル効果量表示時に上限で赤色表示に。奥義、奥義上限、奥義ゲージ上昇量のキャラLB追加。",
+        "zh": "2019/06/06: Added Recent uncaps, Color for upper limit when you display DA/TA skill amount, Character LB of ougiDamage, ougiDamageLimit, ougiGageBuff",
     },
 };
 

--- a/src/translate.js
+++ b/src/translate.js
@@ -316,6 +316,27 @@ var multiLangData = {
         "ja": "与ダメージ上昇効果。虚空斧奥義(10000)など。",
         "zh": "DMG Boosted status effect. Hollowsky Axe's C.A. (10000), etc.",
     },
+    "奥義ダメージバフ": {
+        "en": "C.A. DMG Buff",
+        "ja": "奥義ダメージバフ",
+        "zh": "C.A. DMG Buff",
+    },
+    "奥義ゲージ上昇量バフ": {
+        "en": "Charge Bar Speed UP Buff",
+        "ja": "奥義ゲージ上昇量バフ",
+        "zh": "Charge Bar Speed UP Buff",
+    },
+    "ダメージ上限バフ": {
+        "en": "DMG Cap Buff",
+        "ja": "ダメージ上限バフ",
+        "zh": "DMG Cap Buff",
+    },
+    "奥義ダメージ上限バフ": {
+        "en": "C.A. DMG Buff",
+        "ja": "奥義ダメージ上限バフ",
+        "zh": "C.A. DMG Buff",
+    },
+	
     "与ダメージ上昇": {
         "en": "Damage UP ",
         "ja": "与ダメージ上昇",
@@ -348,7 +369,7 @@ var multiLangData = {
     },
     "奥義ゲージ上昇量": {
         "en": "Charge Bar Buff", //a.k.a: ougiGageBuff
-        "ja": "奥義ゲージ\n上昇量",
+        "ja": "奥義ゲージ上昇量",
         "zh": "奥义槽上升量",
     },
     "奥義ゲージ上昇率アップ": {
@@ -358,7 +379,7 @@ var multiLangData = {
     },
     "奥義ゲージ上昇率アップ説明": {
         "en": "Used on the expected turn damage calculation.",
-        "ja": "攻撃回数に応じた奥義ゲージ上昇量に影響します。予想ターン毎ダメージの算出に使用されます。",
+        "ja": "攻撃等の奥義ゲージ上昇量に影響します。予想ターン毎ダメージの算出に使用されます。",
         "zh": "影响奥义槽上升量。在预想DPT计算中有用到。",
     },
     "チェインダメージアップ": {
@@ -387,18 +408,18 @@ var multiLangData = {
         "zh": "奥义伤害上限上升",
     },
     "奥義ダメージ上限アップ説明": {
-        "en": "It is used to calc the Ougi damage.",
+        "en": "It is used to calc the C.A damage.",
         "ja": "奥義ダメージの算出に使用されます。",
         "zh": "奥义伤害的计算中有用到。",
 	},
     "奥義ゲージ上昇奥義": {
         "en": "Charge Boost C.A.",
-        "ja": "奥義ゲージ上昇奥義",
+        "ja": "奥義時の奥義ゲージ上昇効果",
         "zh": "Charge Boost C.A.",
     },
     "奥義ゲージ上昇奥義説明": {
         "en": "Decrease the maximum Charge Bar value by the effect size. Unsigned Kaneshige(10%) etc.",
-        "ja": "奥義ゲージ最大値を効果分マイナスします(奥義ゲージ上昇率バフも加味)。無銘金重(10%)など",
+        "ja": "奥義ゲージ最大値を効果分マイナスして擬似的に再現します(奥義ゲージ上昇率バフも加味)。無銘金重(10%)など",
         "zh": "Decrease the maximum Charge Bar value by the effect size. Unsigned Kaneshige(10%) etc.",
 	},
     "Advanced": {
@@ -794,13 +815,13 @@ var multiLangData = {
         "zh": "基础TA率",
     },
     "パーティバフタイトル": {
-        "en": "Buff for Party (Percentage)",
-        "ja": "パーティ全体へのバフ等 (%表記)",
-        "zh": "全队Buff (百分比)",
+        "en": "Buff for Party",
+        "ja": "パーティ全体へのバフ等",
+        "zh": "全队Buff",
     },
     "パーティバフ説明": {
-        "en": "Input buffs for a party.",
-        "ja": "パーティメンバ全体にかかるバフ等の情報を入力してください",
+        "en": "Input buffs for a party.(There is no Duration and it will be reflected permanently.)",
+        "ja": "パーティメンバー全体にかかるバフ等の情報を入力してください。(効果ターンはなく永続的に反映されます)",
         "zh": "输入全队Buff",
     },
     "保存済みリスト名説明": {

--- a/src/translate.js
+++ b/src/translate.js
@@ -312,9 +312,9 @@ var multiLangData = {
         "zh": "Supplemental Damage Buff",
     },
     "supplementalDamageBuff-tooltip": {
-        "en": "DMG Boosted status effect. Rosetta (Grand)'s Iron Maiden (5000), Hollowsky Axe's C.A. (10000), etc.",
-        "ja": "与ダメージ上昇効果。ロゼッタ（リミテッド）のアイアン・メイデン(5000)、虚空の晶塊の奥義(10000)など。",
-        "zh": "DMG Boosted status effect. Rosetta (Grand)'s Iron Maiden (5000), Hollowsky Axe's C.A. (10000), etc.",
+        "en": "DMG Boosted status effect. Hollowsky Axe's C.A. (10000), etc.",
+        "ja": "与ダメージ上昇効果。虚空斧奥義(10000)など。",
+        "zh": "DMG Boosted status effect. Hollowsky Axe's C.A. (10000), etc.",
     },
     "与ダメージ上昇": {
         "en": "Damage UP ",
@@ -437,9 +437,9 @@ var multiLangData = {
         "zh": "Enemy Resistance",
     },
     "敵非有利耐性説明": {
-        "en": "Enemy's damage reduction for elements they are not weak to. Unite and Fight's NIGHTMARE(50%) and likes-",
-        "ja": "敵の非有利属性時に生じる耐性を設定します。古戦場HELL(50%)など。",
-        "zh": "Enemy's damage reduction for elements they are not weak to. Unite and Fight's NIGHTMARE(50%) and likes-",
+        "en": "Enemy's damage reduction for elements they are not weak to. Unite and Fight's NIGHTMARE(25%), EX+(50%) and likes-",
+        "ja": "敵の非有利属性時に生じる耐性を設定します。古戦場HELL(20%)、犬EX+(50%)など。",
+        "zh": "Enemy's damage reduction for elements they are not weak to. Unite and Fight's NIGHTMARE(25%), EX+(50%) and likes-",
     },
     "ジータさん基礎DA率説明": {
         "en": "Input base double attack ratio of player.\nIt will be automatically changed when \"Job\" is changed.",
@@ -1250,7 +1250,7 @@ var multiLangData = {
     },
     "与ダメージ上昇効果のソース": {
         "en": "Supplemental Damage Source",
-        "ja": "与ダメージ上昇効果のソース",
+        "ja": "与ダメージ上昇効果の種類",
         "zh": "Supplemental Damage Source",
     },
     "合計": {
@@ -1260,7 +1260,7 @@ var multiLangData = {
     },
     "ダメージ": {
         "en": "Damage (incl. Damage UP and Enemy Resistance)",
-        "ja": "ダメージ  (与ダメージ上と敵非有利耐性昇を含むいる)",
+        "ja": "ダメージ  (与ダメージ上昇と敵非有利耐性が反映済み)",
         "zh": "伤害 (incl. Damage UP and Enemy Resistance)",
     },
     "サポアビ": {
@@ -2983,22 +2983,22 @@ var multiLangData = {
         "zh": "Omega-勇气",
     },
     "ガフスキー[α]": {
-        "en": "Gauph Key α",
+        "en": "Gauph Key α (Normal Attack Cap 10%)",
         "ja": "ガフスキー[α](通常上限10%UP)",
         "zh": "1技能插件[α]",
     },
     "ガフスキー[β]": {
-        "en": "Gauph Key β",
+        "en": "Gauph Key β (Skill Cap 50%)",
         "ja": "ガフスキー[β](アビ上限50%UP)",
         "zh": "1技能插件[β]",
     },
     "ガフスキー[γ]": {
-        "en": "Gauph Key γ",
+        "en": "Gauph Key γ (C.A. Cap 15%)",
         "ja": "ガフスキー[γ](奥義上限15%UP)",
         "zh": "1技能插件[γ]",
     },
     "ガフスキー[Δ]": {
-        "en": "Gauph Key Δ",
+        "en": "Gauph Key Δ (CB Cap 50%)",
         "ja": "ガフスキー[Δ](CB上限50%UP)",
         "zh": "1技能插件[Δ]",
     },
@@ -3053,22 +3053,22 @@ var multiLangData = {
         "zh": "災禍の誓約",
     },
     "ペンデュラム[α]": {
-        "en": "Pendulum Key α",
+        "en": "Pendulum Key α (Normal Attack Cap 10%)",
         "ja": "ペンデュラム[α](通常上限10%UP)",
         "zh": "ペンデュラム[α](通常上限10%UP)",
     },
     "ペンデュラム[β]": {
-        "en": "Pendulum Key β",
+        "en": "Pendulum Key β (Skill Cap 50%)",
         "ja": "ペンデュラム[β](アビ上限50%UP)",
         "zh": "ペンデュラム[β](アビ上限50%UP)",
     },
     "ペンデュラム[γ]": {
-        "en": "Pendulum Key γ",
+        "en": "Pendulum Key γ (C.A. Cap 15%)",
         "ja": "ペンデュラム[γ](奥義上限15%UP)",
         "zh": "ペンデュラム[γ](奥義上限15%UP)",
     },
     "ペンデュラム[Δ]": {
-        "en": "Pendulum Key Δ",
+        "en": "Pendulum Key Δ (CB Cap 50%)",
         "ja": "ペンデュラム[Δ](CB上限50%UP)",
         "zh": "ペンデュラム[Δ](CB上限50%UP)",
     },


### PR DESCRIPTION
・Add notice
・Update translate.js
Delete "Rosetta (Grand)'s Iron Maiden (5000)" because it's duration is short, and usage rate is not high.

Change enemy resistance discription to " Unite and Fight's NIGHTMARE(25%), EX+(50%)"
https://gran-matome.com/archives/57946
https://twitter.com/Granblue_GW/status/1118104526706229248

Others

・Fix supplementalDamageBuff Field
It differed from the original behavior and the entered number was reflected immediately.

・Update notice.js
・Change input-suggest placement
・Change notation in profile


---
提案：保存タブの「スキル性能・各種計算式」表削除(更新が大変なのと、スキル効果量はスキル合計で見ることができるので)
