### PR TITLE
Fix whiteout in result.js

### DIFF
--- a/src/result.js
+++ b/src/result.js
@@ -1379,7 +1379,7 @@ var Result = CreateClass({
                                     <span key={key + "-" + skillKey}>
                                             <span
                                                 className={"label label-" + labelType}>{intl.translate(label, locale)}</span>&nbsp;
-                                        {(m.data[key][skillKey]).toFixed(1)}&nbsp;
+                                        {parseFloat(m.data[key][skillKey]).toFixed(1)}&nbsp;
                                         </span>
                                 );
                             }


### PR DESCRIPTION
When I opened the existing save data and display skill amount, motocal occurs white-out screen.
It seems that ougiRatio or ougiFixedDamage or ougiBonusPlainDamage is not recognized as a number.