### PR TITLE
Fix support ability graph/simulator whiteout

### DIFF
--- a/src/chart.js
+++ b/src/chart.js
@@ -25,7 +25,7 @@ var HPChart = CreateClass({
         var chara = props.chara;
         var totalBuff = getTotalBuff(prof);
         var totals = getInitialTotals(prof, chara, summon);
-        treatSupportAbility(totals, chara);
+        treatSupportAbility(totals, chara, totalBuff);
 
         var res = [];
         for (var i = 0; i < summon.length; i++) {

--- a/src/simulator.js
+++ b/src/simulator.js
@@ -236,7 +236,7 @@ var Simulator = CreateClass({
 
         var totalBuff = getTotalBuff(prof);
         var totals = getInitialTotals(prof, chara, summon);
-        treatSupportAbility(totals, chara);
+        treatSupportAbility(totals, chara, totalBuff);
 
         var sortkey = "averageExpectedDamage";
 


### PR DESCRIPTION
> バグ内容：シヴァ(キャラ)を入れて「背水渾身グラフを開く」を押下した時、正常に画面遷移されずホワイトアウトする。
> 原因：シヴァ(キャラ)のサポアビのパラメータが正常に取得できていない可能性が高い
> https://docs.google.com/spreadsheets/d/1zH5OKPLSbFiNhXOjy1GNgqjjHMvDOEwu2Ani1v54nxE/edit#gid=2011749702

We need to be careful when adding arguments.