### PR TITLE
Fix graph was not appeared for same summon aura entries

### DIFF
--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -221,8 +221,11 @@ module.exports.getTypeBonus = function (self_elem, enemy_elem) {
         }
     };
 
-module.exports.makeSummonHeaderString = function (summon, locale) {
+module.exports.makeSummonHeaderString = function (summon, locale, idx=0) {
     var summonHeader = "";
+    if (idx > 0) {
+        summonHeader += "No." + idx + " ";
+    }
     if (summon.selfSummonType == "odin") {
         summonHeader += intl.translate("属性攻", locale) + summon.selfSummonAmount + intl.translate("キャラ攻", locale) + summon.selfSummonAmount2
     } else {
@@ -2990,7 +2993,7 @@ module.exports.generateHaisuiData = function (res, arml, summon, prof, chara, st
 
     for (var s = 0; s < res.length; s++) {
         var oneresult = res[s];
-        var summonHeader = module.exports.makeSummonHeaderString(summon[s], locale);
+        var summonHeader = module.exports.makeSummonHeaderString(summon[s], locale, s+1);
         var TotalAttack = [["残りHP(%)"]];
         var TotalHP = [["残りHP(%)"]];
         var CriticalAttack = [["残りHP(%)"]];

--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -224,6 +224,8 @@ module.exports.getTypeBonus = function (self_elem, enemy_elem) {
 module.exports.makeSummonHeaderString = function (summon, locale, idx=0) {
     var summonHeader = "";
     if (idx > 0) {
+        // Don't remove "idx"
+        // summonHeader must be unique as dictionary key
         summonHeader += "No." + idx + " ";
     }
     if (summon.selfSummonType == "odin") {


### PR DESCRIPTION
This patch will fix #333

NOTE: It is not just summon label display format change,
free to change the display format, but don't remove the index number.

generateHaisuiData() use returned string of makeSummonHeaderString
as ditionary key, then the string must be unique.

This patch add index number to avoid the key conflict.

----

I will explain how this patch can resolve #333 

The Problem was:
```js
var data = {};

data["火マグナ120 + 火属性140"] = 1;
data["火マグナ120 + 火属性140"] = 2;  // XXX: same key override previous data

// result: data = {
//   "火マグナ120 + 火属性140"]: 2,
// }
```

reported on #333 was appear only summon2 graph.
no summon1 data because of override by the same key.

Solution: given index number to be unique key
```js
var data = {};

data["No.1 火マグナ120 + 火属性140"] = 1;
data["No.2 火マグナ120 + 火属性140"] = 2;

// result: data = {
//   "No.1 火マグナ120 + 火属性140": 1,  // OK: keep summon No1 
//   "No.2 火マグナ120 + 火属性140": 2,
// }
```